### PR TITLE
Provision CRDs before controller startup

### DIFF
--- a/pkg/controller/velero/velero.go
+++ b/pkg/controller/velero/velero.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -34,23 +33,6 @@ const (
 
 func (r *ReconcileVelero) provisionVelero(reqLogger logr.Logger, namespace string, platformStatus *configv1.PlatformStatus, instance *veleroCR.Velero) (reconcile.Result, error) {
 	var err error
-
-	// Install CRDs
-	for _, crd := range veleroInstall.CRDs() {
-		found := &apiextv1beta1.CustomResourceDefinition{}
-		if err = r.client.Get(context.TODO(), types.NamespacedName{Name: crd.ObjectMeta.Name}, found); err != nil {
-			if errors.IsNotFound(err) {
-				// Didn't find CRD, we should create it.
-				reqLogger.Info("Creating CRD", "CRD.Name", crd.ObjectMeta.Name)
-				if err = r.client.Create(context.TODO(), crd); err != nil {
-					return reconcile.Result{}, err
-				}
-			} else {
-				// Return other errors
-				return reconcile.Result{}, err
-			}
-		}
-	}
 
 	locationConfig := make(map[string]string)
 	locationConfig["region"] = platformStatus.AWS.Region

--- a/pkg/velero/crds.go
+++ b/pkg/velero/crds.go
@@ -1,0 +1,36 @@
+package velero
+
+import (
+	"context"
+
+	veleroInstall "github.com/heptio/velero/pkg/install"
+
+	"github.com/go-logr/logr"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func InstallVeleroCRDs(log logr.Logger, client client.Client) error {
+	var err error
+
+	// Install CRDs
+	for _, crd := range veleroInstall.CRDs() {
+		found := &apiextv1beta1.CustomResourceDefinition{}
+		if err = client.Get(context.TODO(), types.NamespacedName{Name: crd.ObjectMeta.Name}, found); err != nil {
+			if errors.IsNotFound(err) {
+				// Didn't find CRD, we should create it.
+				log.Info("Creating CRD", "CRD.Name", crd.ObjectMeta.Name)
+				if err = client.Create(context.TODO(), crd); err != nil {
+					return err
+				}
+			} else {
+				// Return other errors
+				return err
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
We are trying to watch resources that haven't been provisioned:
```
{"level":"error","ts":1566942156.7766368,"logger":"kubebuilder.source","msg":"if kind is a CRD, it should be installed before calling Start","kind":"BackupStorageLocation.velero.io","error":"no matches for kind \"BackupStorageLocation\" in version \"velero.io/v1\"","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tpkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/source.(*Kind).Start\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.1.12/pkg/source/source.go:89\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Watch\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.1.12/pkg/internal/controller/controller.go:122\ngithub.com/openshift/managed-velero-operator/pkg/controller/velero.add\n\tsrc/github.com/openshift/managed-velero-operator/pkg/controller/velero/controller.go:59\ngithub.com/openshift/managed-velero-operator/pkg/controller/velero.Add\n\tsrc/github.com/openshift/managed-velero-operator/pkg/controller/velero/controller.go:36\ngithub.com/openshift/managed-velero-operator/pkg/controller.AddToManager\n\tsrc/github.com/openshift/managed-velero-operator/pkg/controller/controller.go:13\nmain.main\n\tsrc/github.com/openshift/managed-velero-operator/cmd/manager/main.go:175\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:200"}
{"level":"error","ts":1566942156.7767093,"logger":"managed-velero-operator","msg":"","error":"no matches for kind \"BackupStorageLocation\" in version \"velero.io/v1\"","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tpkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nmain.main\n\tsrc/github.com/openshift/managed-velero-operator/cmd/manager/main.go:176\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:200"}
```

Moved CRD check/installation to the manager startup code.