### PR TITLE
Fix nil pointer dereference when setting sync timestamp

### DIFF
--- a/pkg/controller/velero/s3.go
+++ b/pkg/controller/velero/s3.go
@@ -6,6 +6,7 @@ import (
 
 	veleroCR "github.com/openshift/managed-velero-operator/pkg/apis/managed/v1alpha1"
 	"github.com/openshift/managed-velero-operator/pkg/s3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -115,7 +116,9 @@ func (r *ReconcileVelero) provisionS3(reqLogger logr.Logger, s3Client *awss3.S3,
 	}
 
 	instance.Status.S3Bucket.Provisioned = true
-	instance.Status.S3Bucket.LastSyncTimestamp.Time = time.Now()
+	instance.Status.S3Bucket.LastSyncTimestamp = &metav1.Time{
+		Time: time.Now(),
+	}
 	return reconcile.Result{}, r.statusUpdate(reqLogger, instance)
 }
 


### PR DESCRIPTION
Observed a nil pointer dereference issue when initially setting the sync timestamp:
```
E0828 17:41:00.984876       1 runtime.go:69] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
pkg/mod/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628/pkg/util/runtime/runtime.go:76
pkg/mod/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628/pkg/util/runtime/runtime.go:65
pkg/mod/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628/pkg/util/runtime/runtime.go:51
/usr/local/go/src/runtime/panic.go:522
/usr/local/go/src/runtime/panic.go:82
/usr/local/go/src/runtime/signal_unix.go:390
src/github.com/openshift/managed-velero-operator/pkg/controller/velero/s3.go:118
src/github.com/openshift/managed-velero-operator/pkg/controller/velero/controller.go:150
pkg/mod/sigs.k8s.io/controller-runtime@v0.1.12/pkg/internal/controller/controller.go:215
pkg/mod/sigs.k8s.io/controller-runtime@v0.1.12/pkg/internal/controller/controller.go:158
pkg/mod/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628/pkg/util/wait/wait.go:133
pkg/mod/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628/pkg/util/wait/wait.go:134
pkg/mod/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628/pkg/util/wait/wait.go:88
/usr/local/go/src/runtime/asm_amd64.s:1337
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x14f8e2d]
```

This fixes it by ensuring that the `LastSyncTimestamp` is set.