### PR TITLE
Download and cache go modules in builder container

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,11 +2,16 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 
 # Allow specifying a GOPROXY cache during build to speed up dependency resolution
 ARG GOPROXY
-ENV GOPROXY=$GOPROXY
 
-ENV OPERATOR_PATH=/go/src/github.com/openshift/managed-velero-operator
-COPY . ${OPERATOR_PATH}
+ENV OPERATOR_PATH=/go/src/github.com/openshift/managed-velero-operator \
+    GO111MODULE=on \
+    GOPROXY=$GOPROXY
+
+RUN mkdir -p ${OPERATOR_PATH}
 WORKDIR ${OPERATOR_PATH}
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
 RUN make gobuild
 
 ####

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 
 # Allow specifying a GOPROXY cache during build to speed up dependency resolution
-ARG GOPROXY
+ARG GOPROXY=https://proxy.golang.org
 
 ENV OPERATOR_PATH=/go/src/github.com/openshift/managed-velero-operator \
     GO111MODULE=on \

--- a/standard.mk
+++ b/standard.mk
@@ -27,6 +27,7 @@ OPERATOR_DOCKERFILE ?=build/Dockerfile
 BINFILE=build/_output/bin/$(OPERATOR_NAME)
 MAINPACKAGE=./cmd/manager
 export GO111MODULE=on
+export GOPROXY?=https://proxy.golang.org
 GOENV=GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 GOFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
 
@@ -65,7 +66,7 @@ gobuild: ## Build binary
 
 .PHONY: gotest
 gotest:
-	go test $(TESTOPTS) $(shell GO111MODULE=$(GO111MODULE) go list -mod=readonly -e ./... | egrep -v "/(vendor)/")
+	go test $(TESTOPTS) $(shell GO111MODULE=$(GO111MODULE) GOPROXY=$(GOPROXY) go list -mod=readonly -e ./... | egrep -v "/(vendor)/")
 
 .PHONY: envtest
 envtest: isclean


### PR DESCRIPTION
By copying in just the go.mod and go.sum files, and then running a `go mod download`, we cache the docker layer with the modules and don't need to redownload them each time the code changes. We'll only discard that layer if the go.mod/sum files actually change.