### PR TITLE
Add files needed for app-sre pipeline

### DIFF
--- a/config/templates/managed-velero-operator-csv-template.yaml
+++ b/config/templates/managed-velero-operator-csv-template.yaml
@@ -1,0 +1,50 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: managed-velero-operator-0.0.1
+  namespace: placeholder
+  annotations:
+    categories: A list of comma separated categories that your operator falls under.
+    certified: "false"
+    description: Operator to manage installation of Velero in OpenShift.
+    containerImage: quay.io/app-sre/managed-velero-operator:latest
+    createdAt: "2019-11-11T11:00:00Z"
+    support: Stefanie Forrester
+spec:
+  displayName: Managed Velero Operator
+  description: Operator to manage installation of Velero in OpenShift.
+  keywords:
+  - kubernetes
+  - backup
+  - openshift
+  - velero
+  - storage
+  version: 0.0.1
+  provider:
+    name: Red Hat, Inc
+  maturity: alpha
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: false
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: managed-velero-operator
+        # Rules will be added here by the generate-csv.py script.
+      deployments:
+      - name: managed-velero-operator
+        # Deployment spec will be added here by the generate-csv.py script.
+  customresourcedefinitions:
+    owned:
+    - description: Represents an instance of Velero and its dependencies.
+      displayName: Velero
+      kind: Velero
+      name: veleros.managed.openshift.io
+      version: v1alpha1

--- a/config/templates/managed-velero-operator-csv-template.yaml
+++ b/config/templates/managed-velero-operator-csv-template.yaml
@@ -1,17 +1,23 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: managed-velero-operator-0.0.1
+  name: managed-velero-operator.v0.0.1
   namespace: placeholder
   annotations:
-    categories: A list of comma separated categories that your operator falls under.
     certified: "false"
     description: Operator to manage installation of Velero in OpenShift.
     containerImage: quay.io/app-sre/managed-velero-operator:latest
     createdAt: "2019-11-11T11:00:00Z"
-    support: Stefanie Forrester
+    support: Christoph Blecker
+    alm-examples: '[{"apiVersion":"managed.openshift.io/v1alpha1","kind":"Velero","metadata":{"name":"cluster","namespace":"openshift-velero"}}]'
 spec:
   displayName: Managed Velero Operator
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: Velero
+      name: veleros.managed.openshift.io
+      version: v1alpha1
   description: Operator to manage installation of Velero in OpenShift.
   keywords:
   - kubernetes
@@ -23,15 +29,7 @@ spec:
   provider:
     name: Red Hat, Inc
   maturity: alpha
-  installModes:
-  - type: OwnNamespace
-    supported: true
-  - type: SingleNamespace
-    supported: true
-  - type: MultiNamespace
-    supported: false
-  - type: AllNamespaces
-    supported: false
+  displayName: Managed Velero Operator
   install:
     strategy: deployment
     spec:
@@ -40,11 +38,88 @@ spec:
         # Rules will be added here by the generate-csv.py script.
       deployments:
       - name: managed-velero-operator
-        # Deployment spec will be added here by the generate-csv.py script.
-  customresourcedefinitions:
-    owned:
-    - description: Represents an instance of Velero and its dependencies.
-      displayName: Velero
-      kind: Velero
-      name: veleros.managed.openshift.io
-      version: v1alpha1
+      # Deployment spec will be added here by the generate-csv.py script.
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - managed-velero-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - get
+        - apiGroups:
+          - managed.openshift.io
+          resources:
+          - veleros
+          - veleros/status
+          - veleros/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - velero.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - cloudcredential.openshift.io
+          resources:
+          - credentialsrequests
+          verbs:
+          - '*'
+        serviceAccountName: managed-velero-operator
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  maturity: alpha
+  provider: {}
+  version: 0.0.1

--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# AppSRE team CD
+
+set -exv
+
+_OPERATOR_NAME="managed-velero-operator"
+
+CURRENT_DIR=$(dirname "$0")
+
+BASE_IMG="${_OPERATOR_NAME}"
+QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
+IMG="${BASE_IMG}:latest"
+
+GIT_HASH=$(git rev-parse --short=7 HEAD)
+
+# build the image
+BUILD_CMD="docker build" IMG="$IMG" make docker-build
+
+# push the image
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${QUAY_IMAGE}:latest"
+
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${QUAY_IMAGE}:${GIT_HASH}"
+
+# create and push staging image catalog
+"$CURRENT_DIR"/app_sre_create_image_catalog.sh staging "$QUAY_IMAGE"
+
+# create and push production image catalog
+REMOVE_UNDEPLOYED=true "$CURRENT_DIR"/app_sre_create_image_catalog.sh production "$QUAY_IMAGE"

--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+set -exv
+
+# prefix var with _ so we don't clober the var used during the Make build
+# it probably doesn't matter but we can change it later.
+_OPERATOR_NAME="managed-velero-operator"
+
+BRANCH_CHANNEL="$1"
+QUAY_IMAGE="$2"
+
+GIT_HASH=$(git rev-parse --short=7 HEAD)
+GIT_COMMIT_COUNT=$(git rev-list $(git rev-list --max-parents=0 HEAD)..HEAD --count)
+
+# clone bundle repo
+SAAS_OPERATOR_DIR="saas-${_OPERATOR_NAME}-bundle"
+BUNDLE_DIR="$SAAS_OPERATOR_DIR/${_OPERATOR_NAME}/"
+
+rm -rf "$SAAS_OPERATOR_DIR"
+
+git clone \
+    --branch "$BRANCH_CHANNEL" \
+    https://app:"${APP_SRE_BOT_PUSH_TOKEN}"@gitlab.cee.redhat.com/service/saas-${_OPERATOR_NAME}-bundle.git \
+    "$SAAS_OPERATOR_DIR"
+
+# remove any versions more recent than deployed hash
+REMOVED_VERSIONS=""
+if [[ "$REMOVE_UNDEPLOYED" == true ]]; then
+    DEPLOYED_HASH=$(
+        curl -s "https://gitlab.cee.redhat.com/service/saas-osd-operators/raw/master/${_OPERATOR_NAME}-services/${_OPERATOR_NAME}.yaml" | \
+            docker run --rm -i evns/yq -r '.services[]|select(.name="${_OPERATOR_NAME}").hash'
+    )
+
+    delete=false
+    # Sort based on commit number
+    for version in $(ls $BUNDLE_DIR | sort -t . -k 3 -g); do
+        # skip if not directory
+        [ -d "$BUNDLE_DIR/$version" ] || continue
+
+        if [[ "$delete" == false ]]; then
+            short_hash=$(echo "$version" | cut -d- -f2)
+
+            if [[ "$DEPLOYED_HASH" == "${short_hash}"* ]]; then
+                delete=true
+            fi
+        else
+            rm -rf "${BUNDLE_DIR:?BUNDLE_DIR var not set}/$version"
+            REMOVED_VERSIONS="$version $REMOVED_VERSIONS"
+        fi
+    done
+fi
+
+# generate bundle
+PREV_VERSION=$(ls "$BUNDLE_DIR" | sort -t . -k 3 -g | tail -n 1)
+
+./hack/generate-operator-bundle.py \
+    "$BUNDLE_DIR" \
+    "$PREV_VERSION" \
+    "$GIT_COMMIT_COUNT" \
+    "$GIT_HASH" \
+    "$QUAY_IMAGE:$GIT_HASH"
+
+NEW_VERSION=$(ls "$BUNDLE_DIR" | sort -t . -k 3 -g | tail -n 1)
+
+if [ "$NEW_VERSION" = "$PREV_VERSION" ]; then
+    # stopping script as that version was already built, so no need to rebuild it
+    exit 0
+fi
+
+# create package yaml
+cat <<EOF > $BUNDLE_DIR/${_OPERATOR_NAME}.package.yaml
+packageName: ${_OPERATOR_NAME}
+channels:
+- name: $BRANCH_CHANNEL
+  currentCSV: ${_OPERATOR_NAME}.v${NEW_VERSION}
+EOF
+
+# add, commit & push
+pushd $SAAS_OPERATOR_DIR
+
+git add .
+
+MESSAGE="add version $GIT_COMMIT_COUNT-$GIT_HASH
+
+replaces $PREV_VERSION
+removed versions: $REMOVED_VERSIONS"
+
+git commit -m "$MESSAGE"
+git push origin "$BRANCH_CHANNEL"
+
+popd
+
+# build the registry image
+REGISTRY_IMG="quay.io/app-sre/${_OPERATOR_NAME}-registry"
+DOCKERFILE_REGISTRY="Dockerfile.olm-registry"
+
+cat <<EOF > $DOCKERFILE_REGISTRY
+FROM quay.io/openshift/origin-operator-registry:latest
+
+COPY $SAAS_OPERATOR_DIR manifests
+RUN initializer --permissive
+
+CMD ["registry-server", "-t", "/tmp/terminate.log"]
+EOF
+
+docker build -f $DOCKERFILE_REGISTRY --tag "${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest" .
+
+# push image
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest" \
+    "docker://${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest"
+
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest" \
+    "docker://${REGISTRY_IMG}:${BRANCH_CHANNEL}-${GIT_HASH}"

--- a/hack/app_sre_pr_check.sh
+++ b/hack/app_sre_pr_check.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# AppSRE team CD
+
+set -exv
+
+CURRENT_DIR=$(dirname "$0")
+CRD_DIR="$CURRENT_DIR"/../deploy/crds
+
+if [[ -d $CRD_DIR ]]; then
+	python "$CURRENT_DIR"/validate_yaml.py $CRD_DIR
+
+	if [ "$?" != "0" ]; then
+	    exit 1
+	fi
+
+else
+	echo "WARNING: No crds for validation"
+fi
+
+BASE_IMG="managed-velero-operator"
+IMG="${BASE_IMG}:latest"
+
+BUILD_CMD="docker build" IMG="$IMG" make docker-build

--- a/hack/generate-operator-bundle.py
+++ b/hack/generate-operator-bundle.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+#
+# Generate an operator bundle for publishing to OLM. Copies appropriate files
+# into a directory, and composes the ClusterServiceVersion which needs bits and
+# pieces of our rbac and deployment files.
+#
+# Usage ./hack/generate-operator-bundle.py OUTPUT_DIR PREVIOUS_VERSION GIT_NUM_COMMITS GIT_HASH HIVE_IMAGE
+#
+# Commit count can be obtained with: git rev-list 9c56c62c6d0180c27e1cc9cf195f4bbfd7a617dd..HEAD --count
+# This is the first hive commit, if we tag a release we can then switch to using that tag and bump the base version.
+
+import datetime
+import os
+import sys
+import yaml
+import shutil
+
+# This script will append the current number of commits given as an arg
+# (presumably since some past base tag), and the git hash arg for a final
+# version like: 0.1.189-3f73a592
+VERSION_BASE = "0.1"
+
+if len(sys.argv) != 6:
+    print("USAGE: %s OUTPUT_DIR PREVIOUS_VERSION GIT_NUM_COMMITS GIT_HASH HIVE_IMAGE" % sys.argv[0])
+    sys.exit(1)
+
+outdir = sys.argv[1]
+prev_version = sys.argv[2]
+git_num_commits = sys.argv[3]
+git_hash = sys.argv[4]
+managed_velero_operator_image = sys.argv[5]
+
+full_version = "%s.%s-%s" % (VERSION_BASE, git_num_commits, git_hash)
+print("Generating CSV for version: %s" % full_version)
+
+with open('config/templates/managed-velero-operator-csv-template.yaml', 'r') as stream:
+    csv = yaml.load(stream)
+
+if not os.path.exists(outdir):
+    os.mkdir(outdir)
+
+version_dir = os.path.join(outdir, full_version)
+if not os.path.exists(version_dir):
+    os.mkdir(version_dir)
+
+# Initialize CRD array in CSV
+csv['spec']['customresourcedefinitions']['owned'] = []
+
+# Copy all CSV files over to the bundle output dir:
+# Copy all CRD files over to the bundle output dir:
+crd_files = [ f for f in os.listdir('deploy/crds') if f.endswith('_crd.yaml') ]
+for file_name in crd_files:
+    full_path = os.path.join('deploy/crds', file_name)
+    if (os.path.isfile(os.path.join('deploy/crds', file_name))):
+        shutil.copy(full_path, os.path.join(version_dir, file_name))
+    # Load CRD so we can use attributes from it
+    with open("deploy/crds/{}".format(file_name), "r") as stream:
+        crd = yaml.load(stream)
+    # Update CSV template customresourcedefinitions key
+    csv['spec']['customresourcedefinitions']['owned'].append(
+        {
+            "name": crd["metadata"]["name"],
+            "description": crd["spec"]["names"]["kind"],
+            "displayName": crd["spec"]["names"]["kind"],
+            "kind": crd["spec"]["names"]["kind"],
+            "version": crd["spec"]["version"]
+        }
+    )
+
+csv['spec']['install']['spec']['clusterPermissions'] = []
+
+# Add managed-velero-operator role to the CSV:
+with open('deploy/cluster_role.yaml', 'r') as stream:
+    operator_role = yaml.load(stream)
+    csv['spec']['install']['spec']['clusterPermissions'].append(
+        {
+            'rules': operator_role['rules'],
+            'serviceAccountName': 'managed-velero-operator',
+        })
+
+# Add our deployment spec for the hive operator:
+with open('deploy/operator.yaml', 'r') as stream:
+    operator_components = []
+    operator = yaml.load_all(stream)
+    for doc in operator:
+        operator_components.append(doc)
+    # There is only one yaml document in the operator deployment
+    operator_deployment = operator_components[0]
+    csv['spec']['install']['spec']['deployments'][0]['spec'] = operator_deployment['spec']
+
+# Update the deployment to use the defined image:
+csv['spec']['install']['spec']['deployments'][0]['spec']['template']['spec']['containers'][0]['image'] = managed_velero_operator_image
+
+# Update the versions to include git hash:
+csv['metadata']['name'] = "managed-velero-operator.v%s" % full_version
+csv['spec']['version'] = full_version
+csv['spec']['replaces'] = "managed-velero-operator.v%s" % prev_version
+
+# Set the CSV createdAt annotation:
+now = datetime.datetime.now()
+csv['metadata']['annotations']['createdAt'] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+# Write the CSV to disk:
+csv_filename = "managed-velero-operator.v%s.clusterserviceversion.yaml" % full_version
+csv_file = os.path.join(version_dir, csv_filename)
+with open(csv_file, 'w') as outfile:
+    yaml.dump(csv, outfile, default_flow_style=False)
+print("Wrote ClusterServiceVersion: %s" % csv_file)

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -30,92 +30,95 @@ objects:
         api.openshift.com/managed: 'true'
     resourceApplyMode: sync
     resources:
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: veleros.managed.openshift.io
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .status.s3Bucket.name
+          description: Name of the S3 bucket
+          name: Bucket
+          type: string
+        - JSONPath: .status.s3Bucket.provisioned
+          description: Has the S3 bucket been successfully provisioned
+          name: Provisioned
+          type: boolean
+        - JSONPath: .status.s3Bucket.lastSyncTimestamp
+          name: Last Sync
+          type: date
+        group: managed.openshift.io
+        names:
+          kind: Velero
+          listKind: VeleroList
+          plural: veleros
+          singular: velero
+        scope: Namespaced
+        subresources:
+          status: {}
+        validation:
+          openAPIV3Schema:
+            description: Velero is the Schema for the veleros API
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: VeleroSpec defines the desired state of Velero
+                type: object
+              status:
+                description: VeleroStatus defines the observed state of Velero
+                properties:
+                  s3Bucket:
+                    description: S3Bucket contains details of the S3 storage bucket for
+                      backups
+                    properties:
+                      lastSyncTimestamp:
+                        description: LastSyncTimestamp is the time that the bucket policy
+                          was last synced.
+                        format: date-time
+                        type: string
+                      name:
+                        description: Name is the name of the S3 bucket created to store
+                          Velero backup details
+                        maxLength: 63
+                        type: string
+                      provisioned:
+                        description: Provisioned is true once the bucket has been initially
+                          provisioned.
+                        type: boolean
+                    required:
+                    - provisioned
+                    type: object
+                type: object
+            type: object
+        version: v1alpha1
+        versions:
+        - name: v1alpha1
+          served: true
+          storage: true
     - apiVersion: v1
       kind: Namespace
       metadata:
         name: openshift-velero
-        annotations:
-          openshift.io/node-selector: ''
-    - apiVersion: operators.coreos.com/v1alpha1
-      kind: CatalogSource
-      metadata:
         labels:
-          opsrc-datastore: 'true'
-          opsrc-provider: redhat
-        name: managed-velero-operator-registry
-        namespace: openshift-velero
-      spec:
-        image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
-        displayName: Managed Velero Operator
-        icon:
-          base64data: ''
-          mediatype: ''
-        publisher: Red Hat
-        sourceType: grpc
-    - apiVersion: operators.coreos.com/v1alpha1
-      kind: Subscription
+          openshift.io/cluster-monitoring: "true"
+    - apiVersion: v1
+      kind: ServiceAccount
       metadata:
         name: managed-velero-operator
         namespace: openshift-velero
-      spec:
-        channel: ${CHANNEL}
-        name: managed-velero-operator
-        source: managed-velero-operator-registry
-        sourceNamespace: openshift-velero
-    - apiVersion: operators.coreos.com/v1alpha2
-      kind: OperatorGroup
-      metadata:
-        name: managed-velero-operator
-        namespace: openshift-velero
-      spec:
-        targetNamespaces:
-        - openshift-velero
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: RoleBinding
-      metadata:
-        name: managed-velero-operator-cluster-config-v1-reader
-        namespace: kube-system
-        labels:
-          owner: managed-velero-operator
-          owner.namespace: managed-velero-operator
-      subjects:
-      - kind: ServiceAccount
-        name: managed-velero-operator
-        namespace: openshift-velero
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: cluster-config-v1-reader
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: Role
-      metadata:
-        creationTimestamp: null
-        name: cluster-config-v1-reader
-        namespace: kube-system
-      rules:
-      - apiGroups:
-        - ""
-        resourceNames:
-        - cluster-config-v1
-        resources:
-        - configmaps
-        verbs:
-        - get
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
-        name: managed-velero-operator
-        namespace: openshift-velero
-      subjects:
-      - kind: ServiceAccount
-        name: managed-velero-operator
-        namespace: openshift-velero
-      roleRef:
-        kind: ClusterRole
-        name: managed-velero-operator
-        apiGroup: rbac.authorization.k8s.io
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRole
+      apiVersion: rbac.authorization.k8s.io/v1
+      - kind: ClusterRole
       metadata:
         creationTimestamp: null
         name: managed-velero-operator
@@ -135,99 +138,6 @@ objects:
         - get
         - list
         - watch
-    - apiVersion: cloudcredential.openshift.io/v1
-      kind: CredentialsRequest
-      metadata:
-        name: managed-velero-operator-iam-credentials
-        namespace: openshift-velero
-      spec:
-        secretRef:
-          name: managed-velero-operator-iam-credentials
-          namespace: openshift-velero
-        providerSpec:
-          apiVersion: cloudcredential.openshift.io/v1
-          kind: AWSProviderSpec
-          statementEntries:
-          - effect: Allow
-            action:
-            - s3:CreateBucket
-            - s3:ListBucket
-            - s3:PutBucketAcl
-            - s3:PutBucketPublicAccessBlock
-            - s3:PutEncryptionConfiguration
-            - s3:PutLifecycleConfiguration
-            resource: "*"
-    - apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: managed-velero-operator
-        namespace: openshift-velero
-      spec:
-        replicas: 1
-        selector:
-          matchLabels:
-            name: managed-velero-operator
-        template:
-          metadata:
-            labels:
-              name: managed-velero-operator
-          spec:
-            serviceAccountName: managed-velero-operator
-            containers:
-              - name: managed-velero-operator
-                image: quay.io/openshift-sre/managed-velero-operator
-                command:
-                - managed-velero-operator
-                imagePullPolicy: Always
-                env:
-                  - name: POD_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.name
-                  - name: OPERATOR_NAME
-                    value: "managed-velero-operator"
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: RoleBinding
-      metadata:
-        name: prometheus-k8s
-        namespace: openshift-velero
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: prometheus-k8s
-      subjects:
-      - kind: ServiceAccount
-        name: prometheus-k8s
-        namespace: openshift-monitoring
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: Role
-      metadata:
-        name: prometheus-k8s
-        namespace: openshift-velero
-      rules:
-      - apiGroups:
-        - ""
-        resources:
-        - services
-        - endpoints
-        - pods
-        verbs:
-        - get
-        - list
-        - watch
-      kind: RoleBinding
-    - apiVersion: rbac.authorization.k8s.io/v1
-      metadata:
-        name: managed-velero-operator
-        namespace: openshift-velero
-      subjects:
-      - kind: ServiceAccount
-        name: managed-velero-operator
-        namespace: openshift-velero
-      roleRef:
-        kind: Role
-        name: managed-velero-operator
-        apiGroup: rbac.authorization.k8s.io
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -304,13 +214,100 @@ objects:
         - credentialsrequests
         verbs:
         - '*'
-    - apiVersion: v1
-      kind: ServiceAccount
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        creationTimestamp: null
+        name: cluster-config-v1-reader
+        namespace: kube-system
+      rules:
+      - apiGroups:
+        - ""
+        resourceNames:
+        - cluster-config-v1
+        resources:
+        - configmaps
+        verbs:
+        - get
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        creationTimestamp: null
+        name: prometheus-k8s
+        namespace: openshift-velero
+      rules:
+      - apiGroups:
+        - ""
+        resources:
+        - services
+        - endpoints
+        - pods
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
       metadata:
         name: managed-velero-operator
         namespace: openshift-velero
-      kind: ClusterRoleBinding
+      subjects:
+      - kind: ServiceAccount
+        name: managed-velero-operator
+        namespace: openshift-velero
+      roleRef:
+        kind: ClusterRole
+        name: managed-velero-operator
+        apiGroup: rbac.authorization.k8s.io
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: managed-velero-operator
+        namespace: openshift-velero
+      subjects:
+      - kind: ServiceAccount
+        name: managed-velero-operator
+        namespace: openshift-velero
+      roleRef:
+        kind: Role
+        name: managed-velero-operator
+        apiGroup: rbac.authorization.k8s.io
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: managed-velero-operator-cluster-config-v1-reader
+        namespace: kube-system
+        labels:
+          owner: managed-velero-operator
+          owner.namespace: managed-velero-operator
+      subjects:
+      - kind: ServiceAccount
+        name: managed-velero-operator
+        namespace: openshift-velero
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: cluster-config-v1-reader
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: prometheus-k8s
+        namespace: openshift-velero
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-k8s
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: prometheus-k8s
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: velero
+        namespace: openshift-velero
+      - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
       metadata:
         name: velero
       subjects:
@@ -321,8 +318,62 @@ objects:
         kind: ClusterRole
         name: cluster-admin
         apiGroup: rbac.authorization.k8s.io
-    - apiVersion: v1
-      kind: ServiceAccount
+    - apiVersion: cloudcredential.openshift.io/v1
+      kind: CredentialsRequest
       metadata:
-        name: velero
+        name: managed-velero-operator-iam-credentials
         namespace: openshift-velero
+      spec:
+        secretRef:
+          name: managed-velero-operator-iam-credentials
+          namespace: openshift-velero
+        providerSpec:
+          apiVersion: cloudcredential.openshift.io/v1
+          kind: AWSProviderSpec
+          statementEntries:
+          - effect: Allow
+            action:
+            - s3:CreateBucket
+            - s3:ListBucket
+            - s3:PutBucketAcl
+            - s3:PutBucketPublicAccessBlock
+            - s3:PutEncryptionConfiguration
+            - s3:PutLifecycleConfiguration
+            - s3:PutBucketTagging
+            - s3:DeleteObjectTagging
+            - s3:GetBucketTagging
+            resource: "*"
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: CatalogSource
+      metadata:
+        labels:
+          opsrc-datastore: 'true'
+          opsrc-provider: redhat
+        name: managed-velero-operator-registry
+        namespace: openshift-velero
+      spec:
+        image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
+        displayName: Managed Velero Operator
+        icon:
+          base64data: ''
+          mediatype: ''
+        publisher: Red Hat
+        sourceType: grpc
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: managed-velero-operator
+        namespace: openshift-velero
+      spec:
+        channel: ${CHANNEL}
+        name: managed-velero-operator
+        source: managed-velero-operator-registry
+        sourceNamespace: openshift-velero
+    - apiVersion: operators.coreos.com/v1alpha2
+      kind: OperatorGroup
+      metadata:
+        name: managed-velero-operator
+        namespace: openshift-velero
+      spec:
+        targetNamespaces:
+        - openshift-velero

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1,0 +1,328 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: selectorsyncset-template
+
+parameters:
+- name: REGISTRY_IMG
+  required: true
+- name: CHANNEL
+  value: staging
+  required: true
+- name: IMAGE_TAG
+  required: true
+- name: REPO_NAME
+  value: managed-velero-operator
+  required: true
+
+objects:
+- apiVersion: hive.openshift.io/v1alpha1
+  kind: SelectorSyncSet
+  metadata:
+    name: managed-velero-operator
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-velero
+        annotations:
+          openshift.io/node-selector: ''
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: CatalogSource
+      metadata:
+        labels:
+          opsrc-datastore: 'true'
+          opsrc-provider: redhat
+        name: managed-velero-operator-registry
+        namespace: openshift-velero
+      spec:
+        image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
+        displayName: Managed Velero Operator
+        icon:
+          base64data: ''
+          mediatype: ''
+        publisher: Red Hat
+        sourceType: grpc
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: managed-velero-operator
+        namespace: openshift-velero
+      spec:
+        channel: ${CHANNEL}
+        name: managed-velero-operator
+        source: managed-velero-operator-registry
+        sourceNamespace: openshift-velero
+    - apiVersion: operators.coreos.com/v1alpha2
+      kind: OperatorGroup
+      metadata:
+        name: managed-velero-operator
+        namespace: openshift-velero
+      spec:
+        targetNamespaces:
+        - openshift-velero
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: managed-velero-operator-cluster-config-v1-reader
+        namespace: kube-system
+        labels:
+          owner: managed-velero-operator
+          owner.namespace: managed-velero-operator
+      subjects:
+      - kind: ServiceAccount
+        name: managed-velero-operator
+        namespace: openshift-velero
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: cluster-config-v1-reader
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        creationTimestamp: null
+        name: cluster-config-v1-reader
+        namespace: kube-system
+      rules:
+      - apiGroups:
+        - ""
+        resourceNames:
+        - cluster-config-v1
+        resources:
+        - configmaps
+        verbs:
+        - get
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: managed-velero-operator
+        namespace: openshift-velero
+      subjects:
+      - kind: ServiceAccount
+        name: managed-velero-operator
+        namespace: openshift-velero
+      roleRef:
+        kind: ClusterRole
+        name: managed-velero-operator
+        apiGroup: rbac.authorization.k8s.io
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        creationTimestamp: null
+        name: managed-velero-operator
+        namespace: openshift-velero
+      rules:
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - '*'
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - infrastructures
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: cloudcredential.openshift.io/v1
+      kind: CredentialsRequest
+      metadata:
+        name: managed-velero-operator-iam-credentials
+        namespace: openshift-velero
+      spec:
+        secretRef:
+          name: managed-velero-operator-iam-credentials
+          namespace: openshift-velero
+        providerSpec:
+          apiVersion: cloudcredential.openshift.io/v1
+          kind: AWSProviderSpec
+          statementEntries:
+          - effect: Allow
+            action:
+            - s3:CreateBucket
+            - s3:ListBucket
+            - s3:PutBucketAcl
+            - s3:PutBucketPublicAccessBlock
+            - s3:PutEncryptionConfiguration
+            - s3:PutLifecycleConfiguration
+            resource: "*"
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: managed-velero-operator
+        namespace: openshift-velero
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            name: managed-velero-operator
+        template:
+          metadata:
+            labels:
+              name: managed-velero-operator
+          spec:
+            serviceAccountName: managed-velero-operator
+            containers:
+              - name: managed-velero-operator
+                image: quay.io/openshift-sre/managed-velero-operator
+                command:
+                - managed-velero-operator
+                imagePullPolicy: Always
+                env:
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: OPERATOR_NAME
+                    value: "managed-velero-operator"
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: prometheus-k8s
+        namespace: openshift-velero
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: prometheus-k8s
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-k8s
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: prometheus-k8s
+        namespace: openshift-velero
+      rules:
+      - apiGroups:
+        - ""
+        resources:
+        - services
+        - endpoints
+        - pods
+        verbs:
+        - get
+        - list
+        - watch
+      kind: RoleBinding
+    - apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: managed-velero-operator
+        namespace: openshift-velero
+      subjects:
+      - kind: ServiceAccount
+        name: managed-velero-operator
+        namespace: openshift-velero
+      roleRef:
+        kind: Role
+        name: managed-velero-operator
+        apiGroup: rbac.authorization.k8s.io
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        creationTimestamp: null
+        name: managed-velero-operator
+        namespace: openshift-velero
+      rules:
+      - apiGroups:
+        - ""
+        resources:
+        - pods
+        - services
+        - services/finalizers
+        - endpoints
+        - persistentvolumeclaims
+        - events
+        - configmaps
+        - secrets
+        verbs:
+        - '*'
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        - daemonsets
+        - replicasets
+        - statefulsets
+        verbs:
+        - '*'
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - get
+        - create
+      - apiGroups:
+        - apps
+        resourceNames:
+        - managed-velero-operator
+        resources:
+        - deployments/finalizers
+        verbs:
+        - update
+      - apiGroups:
+        - ""
+        resources:
+        - pods
+        verbs:
+        - get
+      - apiGroups:
+        - apps
+        resources:
+        - replicasets
+        verbs:
+        - get
+      - apiGroups:
+        - managed.openshift.io
+        resources:
+        - veleros
+        - veleros/status
+        - veleros/finalizers
+        verbs:
+        - '*'
+      - apiGroups:
+        - velero.io
+        resources:
+        - '*'
+        verbs:
+        - '*'
+      - apiGroups:
+        - cloudcredential.openshift.io
+        resources:
+        - credentialsrequests
+        verbs:
+        - '*'
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: managed-velero-operator
+        namespace: openshift-velero
+      kind: ClusterRoleBinding
+    - apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: velero
+      subjects:
+      - kind: ServiceAccount
+        name: velero
+        namespace: openshift-velero
+      roleRef:
+        kind: ClusterRole
+        name: cluster-admin
+        apiGroup: rbac.authorization.k8s.io
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: velero
+        namespace: openshift-velero

--- a/hack/validate_yaml.py
+++ b/hack/validate_yaml.py
@@ -1,0 +1,42 @@
+# Usage
+# python validate_yaml.py path/to/file/or/dir
+
+import sys
+import yaml
+from os import listdir
+from os.path import isdir, isfile, join, splitext
+
+usage = 'usage: python validate_yaml.py path/to/file/or/dir'
+
+if len(sys.argv) != 2:
+    print(usage)
+    sys.exit(1)
+
+path = sys.argv[1]
+
+if isfile(path):
+    files = [path]
+elif isdir(path):
+    files = [join(path, f)
+             for f in listdir(path)
+             if isfile(join(path, f))]
+else:
+    print(usage)
+    sys.exit(1)
+
+error = False
+for file_path in files:
+    _, ext = splitext(file_path)
+    if ext not in ['.yml', '.yaml']:
+        continue
+
+    print('validating {}'.format(file_path))
+    with open(file_path, 'r') as f:
+        data = f.read()
+    try:
+        yaml.safe_load_all(data)
+    except Exception as e:
+        print(e)
+        error = True
+
+sys.exit(error)


### PR DESCRIPTION
Added the generic scripts, along with a customized version of
olm-artifacts-template.yaml which includes all of the manifests
from the operator's deploy/ dir (plus namespace). This file contains
the input parameters used by the CI pipeline to deploy the operator via OLM.

https://jira.coreos.com/browse/SREP-2049