### PR TITLE
Force use of modules

### DIFF
--- a/standard.mk
+++ b/standard.mk
@@ -29,7 +29,7 @@ MAINPACKAGE=./cmd/manager
 export GO111MODULE=on
 export GOPROXY?=https://proxy.golang.org
 GOENV=GOOS=linux GOARCH=amd64 CGO_ENABLED=0
-GOFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
+GOFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}" -mod=''
 
 # ex, -v
 TESTOPTS :=


### PR DESCRIPTION
The the project level golang builder is about to be switched to force vendoring mode. This ensures we explicitly maintain the modules mode when building.