### PR TITLE
Enable recovery using existing bucket

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -161,8 +161,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Grab platform status to determine where OpenShift is installed
-	platformStatus, err := platform.GetPlatformStatus(startupClient)
+	// Get infrastructureStatus (which contains the platformStatus).
+	infraStatus, err := platform.GetInfrastructureStatus(startupClient)
+	if err != nil {
+		log.Error(err, "Failed to retrieve infrastructure status")
+		os.Exit(1)
+	}
+	platformStatus, err := platform.GetPlatformStatus(startupClient, infraStatus)
 	if err != nil {
 		log.Error(err, "Failed to retrieve platform status")
 		os.Exit(1)

--- a/deploy/credential_request.yaml
+++ b/deploy/credential_request.yaml
@@ -14,12 +14,13 @@ spec:
     - effect: Allow
       action:
       - s3:CreateBucket
+      - s3:DeleteObjectTagging
+      - s3:GetBucketTagging
+      - s3:ListAllMyBuckets
       - s3:ListBucket
       - s3:PutBucketAcl
       - s3:PutBucketPublicAccessBlock
+      - s3:PutBucketTagging
       - s3:PutEncryptionConfiguration
       - s3:PutLifecycleConfiguration
-      - s3:PutBucketTagging
-      - s3:DeleteObjectTagging
-      - s3:GetBucketTagging
       resource: "*"

--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/openshift/managed-velero-operator/version"
-
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,7 +30,6 @@ func NewS3Client(kubeClient client.Client, region string) (*s3.S3, error) {
 	var err error
 
 	awsConfig := &aws.Config{Region: aws.String(region)}
-
 	namespace, err := k8sutil.GetOperatorNamespace()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get operator namespace: %v", err)

--- a/pkg/util/platform/platform_test.go
+++ b/pkg/util/platform/platform_test.go
@@ -117,8 +117,13 @@ func TestGetPlatformStatus(t *testing.T) {
 			t.Fatalf("unable to create fake configmap object: %v", err)
 		}
 
+		infraStatus, err := GetInfrastructureStatus(fc)
+		if err != nil {
+			t.Fatalf("unable to get fake infrastructureStatus object: %v", err)
+		}
+
 		// Run test and compare
-		ps, err := GetPlatformStatus(fc)
+		ps, err := GetPlatformStatus(fc, infraStatus)
 		if err != nil {
 			t.Errorf("error on retrieving platform status: %v", err)
 		}


### PR DESCRIPTION
If the managed-velero-operator namespace or CR gets deleted,
usually we would have no way of knowing which S3 bucket is associated
with the operator. We would be left with unmanaged S3 resources.

This commit add the ability for managed-velero-operator to recover
from namespace deletion by searching for an existing S3 bucket
associated with velero backups for the cluster on which it is running.

https://issues.redhat.com/browse/OSD-2602