### PR TITLE
Move velero deployment to infra nodes

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,6 +14,18 @@ spec:
         name: managed-velero-operator
     spec:
       serviceAccountName: managed-velero-operator
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+            weight: 1
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
       containers:
         - name: managed-velero-operator
           image: quay.io/openshift-sre/managed-velero-operator

--- a/pkg/controller/velero/velero.go
+++ b/pkg/controller/velero/velero.go
@@ -245,8 +245,28 @@ func veleroDeployment(namespace string) *appsv1.Deployment {
 			MaxSurge:       &maxSurge,
 		},
 	}
+	deployment.Spec.Template.Spec.Tolerations = []corev1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/infra",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
 	deployment.Spec.Template.Spec.Affinity = &corev1.Affinity{
 		NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+				{
+					Weight: 1,
+					Preference: corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "node-role.kubernetes.io/infra",
+								Operator: corev1.NodeSelectorOpExists,
+							},
+						},
+					},
+				},
+			},
 			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 				NodeSelectorTerms: []corev1.NodeSelectorTerm{
 					{


### PR DESCRIPTION
As infra nodes are existing in all OSD v4 clusters,
velero deployments should be moved to infra nodes.