### PR TITLE
Use an interface for the S3 client

### DIFF
--- a/pkg/controller/velero/s3.go
+++ b/pkg/controller/velero/s3.go
@@ -20,9 +20,10 @@ const (
 	bucketPrefix = "managed-velero-backups-"
 )
 
-func (r *ReconcileVelero) provisionS3(reqLogger logr.Logger, s3Client *awss3.S3, instance *veleroCR.Velero, infraName string) (reconcile.Result, error) {
+func (r *ReconcileVelero) provisionS3(reqLogger logr.Logger, s3Client s3.Client, instance *veleroCR.Velero, infraName string) (reconcile.Result, error) {
 	var err error
-	bucketLog := reqLogger.WithValues("S3Bucket.Name", instance.Status.S3Bucket.Name, "S3Bucket.Region", s3Client.Client.Config.Region)
+	config := s3Client.GetAWSClientConfig()
+	bucketLog := reqLogger.WithValues("S3Bucket.Name", instance.Status.S3Bucket.Name, "S3Bucket.Region", *config.Region)
 
 	// This switch handles the provisioning steps/checks
 	switch {

--- a/pkg/controller/velero/s3.go
+++ b/pkg/controller/velero/s3.go
@@ -31,10 +31,17 @@ func (r *ReconcileVelero) provisionS3(reqLogger logr.Logger, s3Client *awss3.S3,
 
 		// Use an existing bucket, if it exists.
 		log.Info("No S3 bucket defined. Searching for existing bucket to use")
-		existingBucket, err := s3.FindExistingBucket(s3Client, infraName)
+		bucketlist, err := s3.ListBuckets(s3Client)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+
+		bucketinfo, err := s3.ListBucketTags(s3Client, bucketlist)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		existingBucket := s3.FindMatchingTags(bucketinfo, infraName)
 		if existingBucket != "" {
 			log.Info(fmt.Sprintf("Recovered existing bucket: %s", existingBucket))
 			instance.Status.S3Bucket.Name = existingBucket

--- a/pkg/s3/bucket.go
+++ b/pkg/s3/bucket.go
@@ -14,16 +14,18 @@ const (
 )
 
 // CreateBucket creates a new S3 bucket.
-func CreateBucket(s3Client *s3.S3, bucketName string) error {
+func CreateBucket(s3Client Client, bucketName string) error {
 	createBucketInput := &s3.CreateBucketInput{
 		ACL:    aws.String(s3.BucketCannedACLPrivate),
 		Bucket: aws.String(bucketName),
 	}
 	// Only set a location constraint if the cluster isn't in us-east-1
 	// https://github.com/boto/boto3/issues/125
-	if *s3Client.Client.Config.Region != "us-east-1" {
+	config := s3Client.GetAWSClientConfig()
+
+	if *config.Region != "us-east-1" {
 		createBucketConfiguation := &s3.CreateBucketConfiguration{
-			LocationConstraint: s3Client.Client.Config.Region,
+			LocationConstraint: config.Region,
 		}
 		createBucketInput.SetCreateBucketConfiguration(createBucketConfiguation)
 	}
@@ -37,7 +39,7 @@ func CreateBucket(s3Client *s3.S3, bucketName string) error {
 }
 
 // DoesBucketExist checks that the bucket exists, and that we have access to it.
-func DoesBucketExist(s3Client *s3.S3, bucketName string) (bool, error) {
+func DoesBucketExist(s3Client Client, bucketName string) (bool, error) {
 	input := &s3.HeadBucketInput{
 		Bucket: aws.String(bucketName),
 	}
@@ -62,7 +64,7 @@ func DoesBucketExist(s3Client *s3.S3, bucketName string) (bool, error) {
 }
 
 // EncryptBucket sets the encryption configuration for the bucket.
-func EncryptBucket(s3Client *s3.S3, bucketName string) error {
+func EncryptBucket(s3Client Client, bucketName string) error {
 	bucketEncryptionInput := &s3.PutBucketEncryptionInput{
 		Bucket: aws.String(bucketName),
 		ServerSideEncryptionConfiguration: &s3.ServerSideEncryptionConfiguration{
@@ -86,7 +88,7 @@ func EncryptBucket(s3Client *s3.S3, bucketName string) error {
 }
 
 // BlockBucketPublicAccess blocks public access to the bucket's contents.
-func BlockBucketPublicAccess(s3Client *s3.S3, bucketName string) error {
+func BlockBucketPublicAccess(s3Client Client, bucketName string) error {
 	publicAccessBlockInput := &s3.PutPublicAccessBlockInput{
 		Bucket: aws.String(bucketName),
 		PublicAccessBlockConfiguration: &s3.PublicAccessBlockConfiguration{
@@ -107,7 +109,7 @@ func BlockBucketPublicAccess(s3Client *s3.S3, bucketName string) error {
 }
 
 // SetBucketLifecycle sets a lifecycle on the specified bucket.
-func SetBucketLifecycle(s3Client *s3.S3, bucketName string) error {
+func SetBucketLifecycle(s3Client Client, bucketName string) error {
 	bucketLifecycleConfigurationInput := &s3.PutBucketLifecycleConfigurationInput{
 		Bucket: aws.String(bucketName),
 		LifecycleConfiguration: &s3.BucketLifecycleConfiguration{
@@ -135,6 +137,8 @@ func SetBucketLifecycle(s3Client *s3.S3, bucketName string) error {
 	return err
 }
 
+// CreateBucketTaggingInput creates an S3 PutBucketTaggingInput object,
+// which is used to associate a list of tags with a bucket.
 func CreateBucketTaggingInput(bucketname string, tags map[string]string) *s3.PutBucketTaggingInput {
 	putInput := &s3.PutBucketTaggingInput{
 		Bucket: aws.String(bucketname),
@@ -154,7 +158,7 @@ func CreateBucketTaggingInput(bucketname string, tags map[string]string) *s3.Put
 
 // ClearBucketTags wipes all existing tags from a bucket so that velero-specific
 // tags can be applied to the bucket instead.
-func ClearBucketTags(s3Client *s3.S3, bucketName string) (err error) {
+func ClearBucketTags(s3Client Client, bucketName string) (err error) {
 	deleteInput := &s3.DeleteBucketTaggingInput{Bucket: aws.String(bucketName)}
 	_, err = s3Client.DeleteBucketTagging(deleteInput)
 	return err
@@ -162,7 +166,7 @@ func ClearBucketTags(s3Client *s3.S3, bucketName string) (err error) {
 
 // TagBucket adds tags to an S3 bucket. The tags are used to indicate that velero backups
 // are stored in the bucket, and to identify the associated cluster.
-func TagBucket(s3Client *s3.S3, bucketName string, backUpLocation string, infraName string) error {
+func TagBucket(s3Client Client, bucketName string, backUpLocation string, infraName string) error {
 	err := ClearBucketTags(s3Client, bucketName)
 	if err != nil {
 		return fmt.Errorf("unable to clear %v bucket tags: %v", bucketName, err)
@@ -180,7 +184,7 @@ func TagBucket(s3Client *s3.S3, bucketName string, backUpLocation string, infraN
 }
 
 // ListBuckets lists all buckets in the AWS account.
-func ListBuckets(s3Client *s3.S3) (*s3.ListBucketsOutput, error) {
+func ListBuckets(s3Client Client) (*s3.ListBucketsOutput, error) {
 	input := &s3.ListBucketsInput{}
 	result, err := s3Client.ListBuckets(input)
 	if err != nil {
@@ -191,7 +195,7 @@ func ListBuckets(s3Client *s3.S3) (*s3.ListBucketsOutput, error) {
 }
 
 // ListBucketTags returns a list of s3.GetBucketTagging objects, one for each bucket.
-func ListBucketTags(s3Client *s3.S3, bucketlist *s3.ListBucketsOutput) (map[string]*s3.GetBucketTaggingOutput, error) {
+func ListBucketTags(s3Client Client, bucketlist *s3.ListBucketsOutput) (map[string]*s3.GetBucketTaggingOutput, error) {
 	taglist := make(map[string]*s3.GetBucketTaggingOutput)
 	for _, bucket := range bucketlist.Buckets {
 		request := &s3.GetBucketTaggingInput{

--- a/pkg/s3/bucket.go
+++ b/pkg/s3/bucket.go
@@ -195,14 +195,11 @@ func ListBuckets(s3Client Client) (*s3.ListBucketsOutput, error) {
 }
 
 // ListBucketTags returns a list of s3.GetBucketTagging objects, one for each bucket.
-// If the bucket is not readable, or has no tags, an empty TagSet is returned for that bucket.
+// If the bucket is not readable, or has no tags, the bucket name is omitted from the taglist.
+// So taglist only contains the list of buckets that have tags.
 func ListBucketTags(s3Client Client, bucketlist *s3.ListBucketsOutput) (map[string]*s3.GetBucketTaggingOutput, error) {
 	taglist := make(map[string]*s3.GetBucketTaggingOutput)
-	emptyTagSet := &s3.GetBucketTaggingOutput{
-		TagSet: []*s3.Tag{},
-	}
 	for _, bucket := range bucketlist.Buckets {
-		taglist[*bucket.Name] = emptyTagSet
 		// Sometimes deleted buckets will show up in this list.
 		// In case they are in the process of being deleted, exit gracefully.
 		bucketReadable, err := DoesBucketExist(s3Client, *bucket.Name)

--- a/pkg/s3/bucket_test.go
+++ b/pkg/s3/bucket_test.go
@@ -1,0 +1,106 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+const clusterInfraName = "fakeCluster"
+
+func TestFindMatchingTags(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		bucketinfo map[string]*s3.GetBucketTaggingOutput
+		infraName  string
+		want       string
+	}{
+		// This tests the case of having buckets that don't match our cluster's name.
+		// Since this bucket belongs to a different cluster, we want the function to return "",
+		// indicating that there is no matching bucket name.
+		{
+			name:      "Bucket infraName doesn't match tag.",
+			infraName: "wrongClusterName",
+			bucketinfo: map[string]*s3.GetBucketTaggingOutput{
+				"bucket1": {
+					TagSet: []*s3.Tag{
+						{
+							Key:   aws.String(bucketTagBackupLocation),
+							Value: aws.String("default"),
+						},
+						{
+							Key:   aws.String(bucketTagInfraName),
+							Value: aws.String(clusterInfraName),
+						},
+					},
+				},
+			},
+			want: "",
+		},
+		// This tests the case of having a bucket with a matching infraName, indicating that
+		// the bucket belongs to our cluster. We expect the name of the bucket returned.
+		{
+			name:      "Bucket infraName matches tag.",
+			infraName: clusterInfraName,
+			bucketinfo: map[string]*s3.GetBucketTaggingOutput{
+				"bucket1": {
+					TagSet: []*s3.Tag{
+						{
+							Key:   aws.String(bucketTagBackupLocation),
+							Value: aws.String("default"),
+						},
+						{
+							Key:   aws.String(bucketTagInfraName),
+							Value: aws.String(clusterInfraName),
+						},
+					},
+				},
+			},
+			want: "bucket1",
+		},
+		// This tests the case of two buckets. The first bucket should not match.
+		// The name of the second bucket should be returned.
+		{
+			name:      "Two buckets; second bucket should match.",
+			infraName: clusterInfraName,
+			bucketinfo: map[string]*s3.GetBucketTaggingOutput{
+				"bucket1": {
+					TagSet: []*s3.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/testCluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("Name"),
+							Value: aws.String("testCluster-image-registry"),
+						},
+					},
+				},
+				"bucket2": {
+					TagSet: []*s3.Tag{
+						{
+							Key:   aws.String(bucketTagBackupLocation),
+							Value: aws.String("default"),
+						},
+						{
+							Key:   aws.String(bucketTagInfraName),
+							Value: aws.String(clusterInfraName),
+						},
+					},
+				},
+			},
+			want: "bucket2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FindMatchingTags(tt.bucketinfo, tt.infraName)
+			if got != tt.want {
+				t.Errorf("FindMatchingTags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/s3/bucket_test.go
+++ b/pkg/s3/bucket_test.go
@@ -338,11 +338,7 @@ func TestListBucketTags(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*s3.GetBucketTaggingOutput{
-				"nonExistentBucket": &s3.GetBucketTaggingOutput{
-					TagSet: []*s3.Tag{},
-				},
-			},
+			want:    map[string]*s3.GetBucketTaggingOutput{},
 			wantErr: false,
 		},
 	}

--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
 const (
@@ -26,9 +27,88 @@ var (
 	awsCredsSecretName = version.OperatorName + "-iam-credentials"
 )
 
+// awsClient implements the Client interface.
+type awsClient struct {
+	s3Client s3iface.S3API
+	Config   *aws.Config
+}
+
+// Client is a wrapper object for the actual AWS SDK client to allow for easier testing.
+type Client interface {
+	CreateBucket(*s3.CreateBucketInput) (*s3.CreateBucketOutput, error)
+	DeleteBucketTagging(*s3.DeleteBucketTaggingInput) (*s3.DeleteBucketTaggingOutput, error)
+	HeadBucket(*s3.HeadBucketInput) (*s3.HeadBucketOutput, error)
+	GetAWSClientConfig() *aws.Config
+	GetBucketTagging(*s3.GetBucketTaggingInput) (*s3.GetBucketTaggingOutput, error)
+	GetPublicAccessBlock(*s3.GetPublicAccessBlockInput) (*s3.GetPublicAccessBlockOutput, error)
+	ListBuckets(*s3.ListBucketsInput) (*s3.ListBucketsOutput, error)
+	PutBucketEncryption(*s3.PutBucketEncryptionInput) (*s3.PutBucketEncryptionOutput, error)
+	PutBucketLifecycleConfiguration(*s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error)
+	PutBucketTagging(*s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error)
+	PutPublicAccessBlock(*s3.PutPublicAccessBlockInput) (*s3.PutPublicAccessBlockOutput, error)
+}
+
+// When all of the above Client methods are implemented for awsClient, awsClient becomes a kind of Client.
+
+// CreateBucket implements the CreateBucket method for awsClient.
+func (c *awsClient) CreateBucket(input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
+	return c.s3Client.CreateBucket(input)
+}
+
+// DeleteBucketTagging implements the DeleteBucketTagging method for awsClient.
+func (c *awsClient) DeleteBucketTagging(input *s3.DeleteBucketTaggingInput) (*s3.DeleteBucketTaggingOutput, error) {
+	return c.s3Client.DeleteBucketTagging(input)
+}
+
+// GetAWSClientConfig returns a copy of the AWS Client Config for the awsClient.
+func (c *awsClient) GetAWSClientConfig() *aws.Config {
+	return c.Config
+}
+
+// HeadBucket implements the HeadBucket method for awsClient.
+func (c *awsClient) HeadBucket(input *s3.HeadBucketInput) (*s3.HeadBucketOutput, error) {
+	return c.s3Client.HeadBucket(input)
+}
+
+// GetBucketTagging implements the GetBucketTagging method for awsClient.
+func (c *awsClient) GetBucketTagging(input *s3.GetBucketTaggingInput) (*s3.GetBucketTaggingOutput, error) {
+	return c.s3Client.GetBucketTagging(input)
+}
+
+// GetPublicAccessBlock implements the GetPublicAccessBlock method for awsClient.
+func (c *awsClient) GetPublicAccessBlock(input *s3.GetPublicAccessBlockInput) (*s3.GetPublicAccessBlockOutput, error) {
+	return c.s3Client.GetPublicAccessBlock(input)
+}
+
+// ListBuckets implements the ListBuckets method for awsClient.
+func (c *awsClient) ListBuckets(input *s3.ListBucketsInput) (*s3.ListBucketsOutput, error) {
+	return c.s3Client.ListBuckets(input)
+}
+
+// PutBucketEncryption implements the PutBucketEncryption method for awsClient.
+func (c *awsClient) PutBucketEncryption(input *s3.PutBucketEncryptionInput) (*s3.PutBucketEncryptionOutput, error) {
+	return c.s3Client.PutBucketEncryption(input)
+}
+
+// PutBucketLifecycleConfiguration implements the PutBucketLifecycleConfiguration method for awsClient.
+func (c *awsClient) PutBucketLifecycleConfiguration(
+	input *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error) {
+	return c.s3Client.PutBucketLifecycleConfiguration(input)
+}
+
+// PutBucketTagging implements the PutBucketTagging method for awsClient.
+func (c *awsClient) PutBucketTagging(input *s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error) {
+	return c.s3Client.PutBucketTagging(input)
+}
+
+// PutPublicAccessBlock implements the PutPublicAccessBlock method for awsClient.
+func (c *awsClient) PutPublicAccessBlock(input *s3.PutPublicAccessBlockInput) (*s3.PutPublicAccessBlockOutput, error) {
+	return c.s3Client.PutPublicAccessBlock(input)
+}
+
 // NewS3Client reads the aws secrets in the operator's namespace and uses
 // them to create a new client for accessing the S3 API.
-func NewS3Client(kubeClient client.Client, region string) (*s3.S3, error) {
+func NewS3Client(kubeClient client.Client, region string) (Client, error) {
 	var err error
 
 	awsConfig := &aws.Config{Region: aws.String(region)}
@@ -66,5 +146,9 @@ func NewS3Client(kubeClient client.Client, region string) (*s3.S3, error) {
 		return nil, err
 	}
 
-	return s3.New(s), nil
+	// Load the actual AWS client into the awsClient interface.
+	return &awsClient{
+		s3Client: s3.New(s),
+		Config:   awsConfig,
+	}, nil
 }

--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -26,6 +26,8 @@ var (
 	awsCredsSecretName = version.OperatorName + "-iam-credentials"
 )
 
+// NewS3Client reads the aws secrets in the operator's namespace and uses
+// them to create a new client for accessing the S3 API.
 func NewS3Client(kubeClient client.Client, region string) (*s3.S3, error) {
 	var err error
 


### PR DESCRIPTION
If we use an interface for the S3 client, instead of using the client directly,
we can mock S3 API responses in our unit tests. This commit replaces the `s3.S3` clients
with an interface and adds a couple unit tests using mock API data.

https://issues.redhat.com/browse/OSD-2054