### PR TITLE
Simplify error handling logic around bucket tags

### DIFF
--- a/pkg/s3/bucket.go
+++ b/pkg/s3/bucket.go
@@ -200,25 +200,27 @@ func ListBuckets(s3Client Client) (*s3.ListBucketsOutput, error) {
 func ListBucketTags(s3Client Client, bucketlist *s3.ListBucketsOutput) (map[string]*s3.GetBucketTaggingOutput, error) {
 	taglist := make(map[string]*s3.GetBucketTaggingOutput)
 	for _, bucket := range bucketlist.Buckets {
-		// Sometimes deleted buckets will show up in this list.
-		// In case they are in the process of being deleted, exit gracefully.
-		bucketReadable, err := DoesBucketExist(s3Client, *bucket.Name)
-		if err != nil {
-			return taglist, err
+		request := &s3.GetBucketTaggingInput{
+			Bucket: aws.String(*bucket.Name),
 		}
-		if bucketReadable {
-			request := &s3.GetBucketTaggingInput{
-				Bucket: aws.String(*bucket.Name),
-			}
-			response, err := s3Client.GetBucketTagging(request)
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "NoSuchTagSet" {
-				// If there is no tag set, exit this function without error.
-				return taglist, nil
-			} else if err != nil {
+		response, err := s3Client.GetBucketTagging(request)
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				switch aerr.Code() {
+				case "NoSuchTagSet":
+					// There are no tags on this bucket, continue.
+					continue
+				case "NoSuchBucket":
+					// The bucket specified no longer exists (can be due to delays in AWS API), continue.
+					continue
+				default:
+					return taglist, err
+				}
+			} else {
 				return taglist, err
 			}
-			taglist[*bucket.Name] = response
 		}
+		taglist[*bucket.Name] = response
 	}
 	return taglist, nil
 }

--- a/pkg/s3/bucket_test.go
+++ b/pkg/s3/bucket_test.go
@@ -311,7 +311,7 @@ func TestListBucketTags(t *testing.T) {
 				},
 			},
 			want: map[string]*s3.GetBucketTaggingOutput{
-				"testBucket": &s3.GetBucketTaggingOutput{
+				"testBucket": {
 					TagSet: []*s3.Tag{
 						{
 							Key:   aws.String(bucketTagBackupLocation),
@@ -327,18 +327,22 @@ func TestListBucketTags(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Ensure that bucket named 'nonExistentBucket' returns empty TagSet",
+			name: "Ensure that bucket named 'nonTaggedBucket' returns empty TagSet",
 			args: args{
 				s3Client: &fakeClient,
 				bucketlist: &s3.ListBucketsOutput{
 					Buckets: []*s3.Bucket{
 						{
-							Name: aws.String("nonExistentBucket"),
+							Name: aws.String("nonTaggedBucket"),
 						},
 					},
 				},
 			},
-			want:    map[string]*s3.GetBucketTaggingOutput{},
+			want: map[string]*s3.GetBucketTaggingOutput{
+				"nonTaggedBucket": {
+					TagSet: []*s3.Tag{},
+				},
+			},
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
This simplifies this code piece down to one API call, and also doesn't exist the function completely if a single bucket errors.