### PR TITLE
Fix image building

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,14 +1,7 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
 
-# Allow specifying a GOPROXY cache during build to speed up dependency resolution
-ARG GOPROXY=https://proxy.golang.org
-
-ENV OPERATOR_PATH=/go/src/github.com/openshift/managed-velero-operator \
-    GO111MODULE=on \
-    GOPROXY=$GOPROXY
-
-RUN mkdir -p ${OPERATOR_PATH}
-WORKDIR ${OPERATOR_PATH}
+RUN mkdir -p /workdir
+WORKDIR /workdir
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
@@ -17,13 +10,10 @@ RUN make gobuild
 ####
 FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
-ENV OPERATOR_PATH=/go/src/github.com/openshift/managed-velero-operator \
-    OPERATOR_BIN=managed-velero-operator \
-    USER_UID=1001 \
+ENV USER_UID=1001 \
     USER_NAME=managed-velero-operator
 
-# install operator binary
-COPY --from=builder ${OPERATOR_PATH}/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}
+COPY --from=builder /workdir/build/_output/bin/* /usr/local/bin/
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup

--- a/standard.mk
+++ b/standard.mk
@@ -26,9 +26,7 @@ OPERATOR_DOCKERFILE ?=build/Dockerfile
 
 BINFILE=build/_output/bin/$(OPERATOR_NAME)
 MAINPACKAGE=./cmd/manager
-export GO111MODULE=on
 unexport GOFLAGS
-export GOPROXY?=https://proxy.golang.org
 GOENV=GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
 


### PR DESCRIPTION
Currently image building is failing with the following:
```
STEP 13: ENV OPERATOR_PATH=/go/src/github.com/openshift/managed-velero-operator OPERATOR_BIN=managed-velero-operator USER_UID=1001 USER_NAME=managed-velero-operator
STEP 14: COPY --from=builder ${OPERATOR_PATH}/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}
error: build error: error dry-running "COPY --from=builder ${OPERATOR_PATH}/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}": no files found matching "/var/lib/containers/storage/overlay/e510bc260364c86e7210deccc8cd369fd5ae4ff06a8b9d9c50fd5080c2455b00/merged/build/_output/bin": no such file or directory
```

This should fix it up. We don't need to be in the gopath as we are using modules and are building in go1.13