### PR TITLE
Follow ups from Storage Driver refactor

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,9 +35,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
-	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )

--- a/pkg/controller/velero/controller.go
+++ b/pkg/controller/velero/controller.go
@@ -141,13 +141,14 @@ func (r *ReconcileVelero) Reconcile(request reconcile.Request) (reconcile.Result
 		return reconcile.Result{}, fmt.Errorf("unable to determine AWS region")
 	}
 
-	//get a driver
+	// Create the Storage Driver
 	drv := storage.NewDriver(infraStatus, r.client)
 
 	// Check if bucket needs to be reconciled
 	if instance.StorageBucketReconcileRequired(s3ReconcilePeriod) {
-		//Create Storage
-		return reconcile.Result{Requeue: true}, drv.CreateStorage(reqLogger, instance)
+		// Create storage using the storage driver
+		// Always return from this, as we will either be updating the status *or* there will be an error.
+		return reconcile.Result{}, drv.CreateStorage(reqLogger, instance)
 	}
 
 	// Now go provision Velero

--- a/pkg/controller/velero/controller.go
+++ b/pkg/controller/velero/controller.go
@@ -147,7 +147,7 @@ func (r *ReconcileVelero) Reconcile(request reconcile.Request) (reconcile.Result
 	// Check if bucket needs to be reconciled
 	if instance.StorageBucketReconcileRequired(s3ReconcilePeriod) {
 		//Create Storage
-		err := drv.CreateStorage(reqLogger, instance, infraStatus.InfrastructureName)
+		err := drv.CreateStorage(reqLogger, instance)
 		if err != nil {
 			fmt.Println(err)
 		}

--- a/pkg/controller/velero/controller.go
+++ b/pkg/controller/velero/controller.go
@@ -147,11 +147,7 @@ func (r *ReconcileVelero) Reconcile(request reconcile.Request) (reconcile.Result
 	// Check if bucket needs to be reconciled
 	if instance.StorageBucketReconcileRequired(s3ReconcilePeriod) {
 		//Create Storage
-		err := drv.CreateStorage(reqLogger, instance)
-		if err != nil {
-			fmt.Println(err)
-		}
-
+		return reconcile.Result{Requeue: true}, drv.CreateStorage(reqLogger, instance)
 	}
 
 	// Now go provision Velero

--- a/pkg/controller/velero/velero.go
+++ b/pkg/controller/velero/velero.go
@@ -9,8 +9,8 @@ import (
 	veleroInstallCR "github.com/openshift/managed-velero-operator/pkg/apis/managed/v1alpha2"
 	storageConstants "github.com/openshift/managed-velero-operator/pkg/storage/constants"
 
-	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	veleroInstall "github.com/vmware-tanzu/velero/pkg/install"
 	appsv1 "k8s.io/api/apps/v1"
@@ -29,13 +29,13 @@ import (
 )
 
 const (
-	awsCredsSecretIDKey          = "aws_access_key_id"     // #nosec G101
-	awsCredsSecretAccessKey      = "aws_secret_access_key" // #nosec G101
-	veleroImageRegistry          = "docker.io/velero"
-	veleroImageRegistryCN        = "registry.docker-cn.com/velero"
-	veleroImageTag               = "velero:v1.3.1"
-	veleroAwsImageTag            = "velero-plugin-for-aws:v1.0.1"
-	credentialsRequestName       = "velero-iam-credentials"
+	awsCredsSecretIDKey     = "aws_access_key_id"     // #nosec G101
+	awsCredsSecretAccessKey = "aws_secret_access_key" // #nosec G101
+	veleroImageRegistry     = "docker.io/velero"
+	veleroImageRegistryCN   = "registry.docker-cn.com/velero"
+	veleroImageTag          = "velero:v1.3.1"
+	veleroAwsImageTag       = "velero-plugin-for-aws:v1.0.1"
+	credentialsRequestName  = "velero-iam-credentials"
 )
 
 func (r *ReconcileVelero) provisionVelero(reqLogger logr.Logger, namespace string, platformStatus *configv1.PlatformStatus, instance *veleroInstallCR.VeleroInstall) (reconcile.Result, error) {
@@ -294,7 +294,7 @@ func veleroDeployment(namespace string, veleroImageRegistry string) *appsv1.Depl
 		veleroInstall.WithEnvFromSecretKey(strings.ToUpper(awsCredsSecretIDKey), credentialsRequestName, awsCredsSecretIDKey),
 		veleroInstall.WithEnvFromSecretKey(strings.ToUpper(awsCredsSecretAccessKey), credentialsRequestName, awsCredsSecretAccessKey),
 		veleroInstall.WithPlugins([]string{veleroImageRegistry + "/" + veleroAwsImageTag}),
-		veleroInstall.WithImage(veleroImageRegistry + "/" + veleroImageTag),
+		veleroInstall.WithImage(veleroImageRegistry+"/"+veleroImageTag),
 	)
 
 	replicas := int32(1)

--- a/pkg/controller/velero/velero.go
+++ b/pkg/controller/velero/velero.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	veleroInstallCR "github.com/openshift/managed-velero-operator/pkg/apis/managed/v1alpha2"
+	storageConstants "github.com/openshift/managed-velero-operator/pkg/storage/constants"
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -35,7 +36,6 @@ const (
 	veleroImageTag               = "velero:v1.3.1"
 	veleroAwsImageTag            = "velero-plugin-for-aws:v1.0.1"
 	credentialsRequestName       = "velero-iam-credentials"
-	defaultBackupStorageLocation = "default"
 )
 
 func (r *ReconcileVelero) provisionVelero(reqLogger logr.Logger, namespace string, platformStatus *configv1.PlatformStatus, instance *veleroInstallCR.VeleroInstall) (reconcile.Result, error) {
@@ -47,7 +47,7 @@ func (r *ReconcileVelero) provisionVelero(reqLogger logr.Logger, namespace strin
 	// Install BackupStorageLocation
 	foundBsl := &velerov1.BackupStorageLocation{}
 	bsl := veleroInstall.BackupStorageLocation(namespace, strings.ToLower(string(platformStatus.Type)), instance.Status.StorageBucket.Name, "", locationConfig)
-	if err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: defaultBackupStorageLocation}, foundBsl); err != nil {
+	if err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: storageConstants.DefaultVeleroBackupStorageLocation}, foundBsl); err != nil {
 		if errors.IsNotFound(err) {
 			// Didn't find BackupStorageLocation
 			reqLogger.Info("Creating BackupStorageLocation")

--- a/pkg/storage/constants/constants.go
+++ b/pkg/storage/constants/constants.go
@@ -1,0 +1,8 @@
+package constants
+
+const (
+	StorageBucketPrefix                = "managed-velero-backups-"
+	DefaultVeleroBackupStorageLocation = "default"
+	BucketTagBackupStorageLocation     = "velero.io/backup-location"
+	BucketTagInfrastructureName        = "velero.io/infrastructureName"
+)

--- a/pkg/storage/s3/bucket_test.go
+++ b/pkg/storage/s3/bucket_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+
+	storageConstants "github.com/openshift/managed-velero-operator/pkg/storage/constants"
 )
 
 const (
@@ -65,7 +67,7 @@ func (c *mockAWSClient) GetBucketTagging(input *s3.GetBucketTaggingInput) (*s3.G
 			TagSet: []*s3.Tag{
 				{
 					Key:   aws.String(bucketTagBackupLocation),
-					Value: aws.String(defaultBackupStorageLocation),
+					Value: aws.String(storageConstants.DefaultVeleroBackupStorageLocation),
 				},
 				{
 					Key:   aws.String(bucketTagInfraName),
@@ -183,7 +185,7 @@ func TestFindMatchingTags(t *testing.T) {
 					TagSet: []*s3.Tag{
 						{
 							Key:   aws.String(bucketTagBackupLocation),
-							Value: aws.String(defaultBackupStorageLocation),
+							Value: aws.String(storageConstants.DefaultVeleroBackupStorageLocation),
 						},
 						{
 							Key:   aws.String(bucketTagInfraName),
@@ -314,7 +316,7 @@ func TestListBucketTags(t *testing.T) {
 					TagSet: []*s3.Tag{
 						{
 							Key:   aws.String(bucketTagBackupLocation),
-							Value: aws.String(defaultBackupStorageLocation),
+							Value: aws.String(storageConstants.DefaultVeleroBackupStorageLocation),
 						},
 						{
 							Key:   aws.String(bucketTagInfraName),

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -19,7 +19,7 @@ import (
 )
 
 type S3 struct {
-	Region string
+	Region    string
 	InfraName string
 }
 
@@ -33,9 +33,9 @@ type driver struct {
 // Used during bootstrapping
 func NewDriver(ctx context.Context, cfg *configv1.InfrastructureStatus, clnt client.Client) *driver {
 	return &driver{
-		Context:    ctx,
-		Config:     &S3{
-			Region: cfg.PlatformStatus.AWS.Region,
+		Context: ctx,
+		Config: &S3{
+			Region:    cfg.PlatformStatus.AWS.Region,
 			InfraName: cfg.InfrastructureName,
 		},
 		kubeClient: clnt,

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -178,7 +178,7 @@ func (d *driver) CreateStorage(reqLogger logr.Logger, instance *veleroInstallCR.
 	}
 
 	instance.Status.StorageBucket.Provisioned = true
-	instance.Status.StorageBucket.LastSyncTimestamp = &v1.Time{
+	instance.Status.StorageBucket.LastSyncTimestamp = &metav1.Time{
 		Time: time.Now(),
 	}
 	return instance.StatusUpdate(reqLogger, d.kubeClient)

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -14,12 +14,8 @@ import (
 	"github.com/google/uuid"
 	configv1 "github.com/openshift/api/config/v1"
 	veleroInstallCR "github.com/openshift/managed-velero-operator/pkg/apis/managed/v1alpha2"
+	storageConstants "github.com/openshift/managed-velero-operator/pkg/storage/constants"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	bucketPrefix                 = "managed-velero-backups-"
-	defaultBackupStorageLocation = "default"
 )
 
 type S3 struct {
@@ -82,7 +78,7 @@ func (d *driver) CreateStorage(reqLogger logr.Logger, instance *veleroInstallCR.
 		}
 
 		// Prepare to create a new bucket, if none exist.
-		proposedName := generateBucketName(bucketPrefix)
+		proposedName := generateBucketName(storageConstants.StorageBucketPrefix)
 		proposedBucketExists, err := d.StorageExists(proposedName)
 		if err != nil {
 			return err
@@ -119,7 +115,7 @@ func (d *driver) CreateStorage(reqLogger logr.Logger, instance *veleroInstallCR.
 				return fmt.Errorf("error occurred when creating bucket %v: %v", instance.Status.StorageBucket.Name, err.Error())
 			}
 		}
-		err = TagBucket(s3Client, instance.Status.StorageBucket.Name, defaultBackupStorageLocation, infraName)
+		err = TagBucket(s3Client, instance.Status.StorageBucket.Name, storageConstants.DefaultVeleroBackupStorageLocation, infraName)
 		if err != nil {
 			return fmt.Errorf("error occurred when tagging bucket %v: %v", instance.Status.StorageBucket.Name, err.Error())
 		}
@@ -172,7 +168,7 @@ func (d *driver) CreateStorage(reqLogger logr.Logger, instance *veleroInstallCR.
 
 	// Make sure that tags are applied to buckets
 	bucketLog.Info("Enforcing S3 Bucket tags on S3 Bucket")
-	err = TagBucket(s3Client, instance.Status.StorageBucket.Name, defaultBackupStorageLocation, infraName)
+	err = TagBucket(s3Client, instance.Status.StorageBucket.Name, storageConstants.DefaultVeleroBackupStorageLocation, infraName)
 	if err != nil {
 		return fmt.Errorf("error occurred when tagging bucket %v: %v", instance.Status.StorageBucket.Name, err.Error())
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -12,7 +12,7 @@ import (
 
 //Driver interface to be satisfied by all present and future storage cloud providers
 type Driver interface {
-	CreateStorage(logr.Logger, *veleroInstallCR.VeleroInstall, string) error
+	CreateStorage(logr.Logger, *veleroInstallCR.VeleroInstall) error
 	StorageExists(string) (bool, error)
 }
 


### PR DESCRIPTION
- Correct the import alias for metav1
- Extract some constants into it's own package so they can be reused
- Move InfraName into the driver, as it's used in different places and is a common configuration piece
- Fix bug where reconcile loop isn't being exited correctly and requeued. We should always requeue after storage reconcile, as there is still the step of provisioning velero to do.