### PR TITLE
Storage driver refactoring

### DIFF
--- a/pkg/controller/velero/velero.go
+++ b/pkg/controller/velero/velero.go
@@ -53,7 +53,7 @@ func (r *ReconcileVelero) provisionVelero(reqLogger logr.Logger, namespace strin
 	var err error
 
 	var locationConfig map[string]string
-	switch platformStatus.Type {
+	switch r.driver.GetPlatformType() {
 	case configv1.AWSPlatformType:
 		locationConfig = map[string]string{
 			"region": platformStatus.AWS.Region,
@@ -64,7 +64,7 @@ func (r *ReconcileVelero) provisionVelero(reqLogger logr.Logger, namespace strin
 		return reconcile.Result{}, fmt.Errorf("unable to determine platform")
 	}
 
-	provider := strings.ToLower(string(platformStatus.Type))
+	provider := strings.ToLower(string(r.driver.GetPlatformType()))
 
 	// Install BackupStorageLocation
 	foundBsl := &velerov1.BackupStorageLocation{}
@@ -133,7 +133,7 @@ func (r *ReconcileVelero) provisionVelero(reqLogger logr.Logger, namespace strin
 	// Install CredentialsRequest
 	foundCr := &minterv1.CredentialsRequest{}
 	var cr *minterv1.CredentialsRequest
-	switch platformStatus.Type {
+	switch r.driver.GetPlatformType() {
 	case configv1.AWSPlatformType:
 		partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), locationConfig["region"])
 		if !ok {
@@ -180,7 +180,7 @@ func (r *ReconcileVelero) provisionVelero(reqLogger logr.Logger, namespace strin
 
 	// Install Deployment
 	foundDeployment := &appsv1.Deployment{}
-	deployment := veleroDeployment(namespace, platformStatus.Type, determineVeleroImageRegistry(platformStatus.Type, locationConfig["region"]))
+	deployment := veleroDeployment(namespace, r.driver.GetPlatformType(), determineVeleroImageRegistry(r.driver.GetPlatformType(), locationConfig["region"]))
 	deploymentName := types.NamespacedName{
 		Namespace: namespace,
 		Name:      "velero",

--- a/pkg/storage/base/base.go
+++ b/pkg/storage/base/base.go
@@ -3,6 +3,7 @@ package base
 import (
 	"context"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -10,4 +11,9 @@ import (
 type Driver struct {
 	Context    context.Context
 	KubeClient client.Client
+}
+
+// GetPlatformType returns the platform type of this driver
+func (d *Driver) GetPlatformType() configv1.PlatformType {
+	return configv1.NonePlatformType
 }

--- a/pkg/storage/base/base.go
+++ b/pkg/storage/base/base.go
@@ -1,0 +1,13 @@
+package base
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Driver holds common fields for storage drivers
+type Driver struct {
+	Context    context.Context
+	KubeClient client.Client
+}

--- a/pkg/storage/gcs/bucket_test.go
+++ b/pkg/storage/gcs/bucket_test.go
@@ -26,9 +26,9 @@ func TestCreateBucket(t *testing.T) {
 			Project:   "dummy-project-id",
 			InfraName: "dummy-infra",
 		},
-		Context:    ctx,
-		kubeClient: fakekubeclient.NewFakeClient(localObjects...),
 	}
+	drv.Context = ctx
+	drv.KubeClient = fakekubeclient.NewFakeClient(localObjects...)
 	err := drv.createBucket(fakeGClient, "dummy-bucket-name")
 	if err != nil {
 		t.Errorf("CreateBucket() Error: %v", err)

--- a/pkg/storage/gcs/gcs.go
+++ b/pkg/storage/gcs/gcs.go
@@ -44,6 +44,11 @@ func NewDriver(ctx context.Context, cfg *configv1.InfrastructureStatus, clnt cli
 	return &drv
 }
 
+// GetPlatformType returns the platform type of this driver
+func (d *driver) GetPlatformType() configv1.PlatformType {
+	return configv1.GCPPlatformType
+}
+
 // CreateStorage attempts to create a GCS bucket and apply any provided tags
 func (d *driver) CreateStorage(reqLogger logr.Logger, instance *veleroInstallCR.VeleroInstall) error {
 	var err error

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	configv1 "github.com/openshift/api/config/v1"
 	veleroInstallCR "github.com/openshift/managed-velero-operator/pkg/apis/managed/v1alpha2"
+	storageBase "github.com/openshift/managed-velero-operator/pkg/storage/base"
 	storageConstants "github.com/openshift/managed-velero-operator/pkg/storage/constants"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -24,22 +25,22 @@ type S3 struct {
 }
 
 type driver struct {
-	Config     *S3
-	Context    context.Context
-	kubeClient client.Client
+	storageBase.Driver
+	Config *S3
 }
 
 // NewDriver creates a new s3 storage driver
 // Used during bootstrapping
 func NewDriver(ctx context.Context, cfg *configv1.InfrastructureStatus, clnt client.Client) *driver {
-	return &driver{
-		Context: ctx,
+	drv := driver{
 		Config: &S3{
 			Region:    cfg.PlatformStatus.AWS.Region,
 			InfraName: cfg.InfrastructureName,
 		},
-		kubeClient: clnt,
 	}
+	drv.Context = ctx
+	drv.KubeClient = clnt
+	return &drv
 }
 
 // CreateStorage attempts to create an s3 bucket
@@ -49,7 +50,7 @@ func (d *driver) CreateStorage(reqLogger logr.Logger, instance *veleroInstallCR.
 	var err error
 
 	// Create an S3 client based on the region we received
-	s3Client, err := NewS3Client(d.kubeClient, d.Config.Region)
+	s3Client, err := NewS3Client(d.KubeClient, d.Config.Region)
 	if err != nil {
 		return err
 	}
@@ -78,7 +79,7 @@ func (d *driver) CreateStorage(reqLogger logr.Logger, instance *veleroInstallCR.
 				case s3.ErrCodeBucketAlreadyExists:
 					bucketLog.Info("Bucket exists, but is not owned by current user; retrying")
 					instance.Status.StorageBucket.Name = ""
-					return instance.StatusUpdate(reqLogger, d.kubeClient)
+					return instance.StatusUpdate(reqLogger, d.KubeClient)
 				case s3.ErrCodeBucketAlreadyOwnedByYou:
 					bucketLog.Info("Bucket exists, and is owned by current user; continue")
 				default:
@@ -106,7 +107,7 @@ func (d *driver) CreateStorage(reqLogger logr.Logger, instance *veleroInstallCR.
 	if !exists {
 		bucketLog.Error(nil, "S3 bucket doesn't appear to exist")
 		instance.Status.StorageBucket.Provisioned = false
-		return instance.StatusUpdate(reqLogger, d.kubeClient)
+		return instance.StatusUpdate(reqLogger, d.KubeClient)
 	}
 
 	// Encrypt S3 bucket
@@ -150,7 +151,7 @@ func (d *driver) CreateStorage(reqLogger logr.Logger, instance *veleroInstallCR.
 	instance.Status.StorageBucket.LastSyncTimestamp = &metav1.Time{
 		Time: time.Now(),
 	}
-	return instance.StatusUpdate(reqLogger, d.kubeClient)
+	return instance.StatusUpdate(reqLogger, d.KubeClient)
 
 }
 
@@ -158,7 +159,7 @@ func (d *driver) CreateStorage(reqLogger logr.Logger, instance *veleroInstallCR.
 func (d *driver) StorageExists(bucketName string) (bool, error) {
 
 	//create an S3 Client
-	s3Client, err := NewS3Client(d.kubeClient, d.Config.Region)
+	s3Client, err := NewS3Client(d.KubeClient, d.Config.Region)
 	if err != nil {
 		return false, err
 	}
@@ -215,7 +216,7 @@ func setInstanceBucketName(d *driver, s3Client Client, reqLogger logr.Logger, in
 		bucketLog.Info("Recovered existing bucket", "StorageBucket.Name", existingBucket)
 		instance.Status.StorageBucket.Name = existingBucket
 		instance.Status.StorageBucket.Provisioned = true
-		return instance.StatusUpdate(reqLogger, d.kubeClient)
+		return instance.StatusUpdate(reqLogger, d.KubeClient)
 	}
 
 	// Prepare to create a new bucket, if none exist.
@@ -231,5 +232,5 @@ func setInstanceBucketName(d *driver, s3Client Client, reqLogger logr.Logger, in
 	bucketLog.Info("Setting proposed bucket name", "StorageBucket.Name", proposedName)
 	instance.Status.StorageBucket.Name = proposedName
 	instance.Status.StorageBucket.Provisioned = false
-	return instance.StatusUpdate(reqLogger, d.kubeClient)
+	return instance.StatusUpdate(reqLogger, d.KubeClient)
 }

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -43,6 +43,11 @@ func NewDriver(ctx context.Context, cfg *configv1.InfrastructureStatus, clnt cli
 	return &drv
 }
 
+// GetPlatformType returns the platform type of this driver
+func (d *driver) GetPlatformType() configv1.PlatformType {
+	return configv1.AWSPlatformType
+}
+
 // CreateStorage attempts to create an s3 bucket
 // and apply any provided tags
 func (d *driver) CreateStorage(reqLogger logr.Logger, instance *veleroInstallCR.VeleroInstall) error {

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -79,12 +79,14 @@ var nullLogr = &logrTesting.NullLogger{}
 func setUpDriver(t *testing.T, instance *velerov1alpha2.VeleroInstall) *driver {
 	t.Helper()
 
-	return &driver{
+	drv := driver{
 		Config: &S3{
 			Region:    region,
 			InfraName: clusterInfraName,
 		},
-		Context:    context.TODO(),
-		kubeClient: setUpTestClient(t, instance),
 	}
+	drv.Context = context.TODO()
+	drv.KubeClient = setUpTestClient(t, instance)
+
+	return &drv
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -14,6 +14,7 @@ import (
 
 //Driver interface to be satisfied by all present and future storage cloud providers
 type Driver interface {
+	GetPlatformType() configv1.PlatformType
 	CreateStorage(logr.Logger, *veleroInstallCR.VeleroInstall) error
 	StorageExists(string) (bool, error)
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
@@ -18,18 +19,29 @@ type Driver interface {
 }
 
 //NewDriver will return a driver object
-func NewDriver(cfg *configv1.InfrastructureStatus, clnt client.Client) Driver {
-
-	ctx := context.Background()
+func NewDriver(cfg *configv1.InfrastructureStatus, client client.Client) (Driver, error) {
 	var driver Driver
 
-	if cfg.PlatformStatus.Type == "AWS" {
-		driver = s3.NewDriver(ctx, cfg, clnt)
+	ctx := context.Background()
+
+	// Verify that we have received the needed platform information
+	switch cfg.PlatformStatus.Type {
+	case configv1.AWSPlatformType:
+		if cfg.PlatformStatus.AWS == nil ||
+			len(cfg.PlatformStatus.AWS.Region) < 1 {
+			return nil, fmt.Errorf("unable to determine AWS region")
+		}
+		driver = s3.NewDriver(ctx, cfg, client)
+	case configv1.GCPPlatformType:
+		if cfg.PlatformStatus.GCP == nil ||
+			len(cfg.PlatformStatus.GCP.Region) < 1 ||
+			len(cfg.PlatformStatus.GCP.ProjectID) < 1 {
+			return nil, fmt.Errorf("unable to determine GCP region")
+		}
+		driver = gcs.NewDriver(ctx, cfg, client)
+	default:
+		return nil, fmt.Errorf("unable to determine platform")
 	}
 
-	if cfg.PlatformStatus.Type == "GCP" {
-		driver = gcs.NewDriver(ctx, cfg, clnt)
-	}
-
-	return driver
+	return driver, nil
 }


### PR DESCRIPTION
This adds a `driver` field to the `ReconcileVelero` struct (initialized during the reconcile loop) so that `reconcileVelero()` can access it.

Also substantially refactors the storage driver methods, adding (in OOP terms) a base class with inherited methods.

Most if not all of the platform-specific logic is now encapsulated in the platform-specific drivers.

Sorry for all the commits, but they're mostly small and gradual.