### PR TITLE
Split up platform-specific controller logic

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -237,7 +237,7 @@ func main() {
 	}
 
 	// Setup all Controllers
-	if err := controller.AddToManager(mgr); err != nil {
+	if err := controller.AddToManager(mgr, infraStatus); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -2,15 +2,16 @@ package controller
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager) error
+var AddToManagerFuncs []func(manager.Manager, *configv1.InfrastructureStatus) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager) error {
+func AddToManager(m manager.Manager, cfg *configv1.InfrastructureStatus) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m); err != nil {
+		if err := f(m, cfg); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/velero/constants.go
+++ b/pkg/controller/velero/constants.go
@@ -1,0 +1,20 @@
+package velero
+
+const (
+	awsCredsSecretIDKey     = "aws_access_key_id"     // #nosec G101
+	awsCredsSecretAccessKey = "aws_secret_access_key" // #nosec G101
+
+	veleroImageRegistry   = "docker.io/velero"
+	veleroImageRegistryCN = "registry.docker-cn.com/velero"
+
+	veleroImageTag    = "velero:v1.3.1"
+	veleroAwsImageTag = "velero-plugin-for-aws:v1.0.1"
+	veleroGcpImageTag = "velero-plugin-for-gcp:v1.0.1"
+
+	credentialsRequestName = "velero-iam-credentials"
+)
+
+var (
+	// Treat as a constant, even though arrays are mutable.
+	awsChinaRegions = []string{"cn-north-1", "cn-northwest-1"}
+)

--- a/pkg/controller/velero/controller.go
+++ b/pkg/controller/velero/controller.go
@@ -115,6 +115,9 @@ type VeleroReconciler interface {
 
 	// RegionInChina returns whether the cloud platform region is in China.
 	RegionInChina() bool
+
+	// GetImageRegistry returns the Velero image registry location.
+	GetImageRegistry() string
 }
 
 // blank assignment to verify that ReconcileVeleroBase implements reconcile.Reconciler

--- a/pkg/controller/velero/controller.go
+++ b/pkg/controller/velero/controller.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/openshift/managed-velero-operator/pkg/storage"
-
 	veleroInstallCR "github.com/openshift/managed-velero-operator/pkg/apis/managed/v1alpha2"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -138,14 +136,6 @@ func (r *ReconcileVeleroBase) Reconcile(request reconcile.Request) (reconcile.Re
 		}
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
-	}
-
-	// Create the Storage Driver
-	if r.driver == nil {
-		r.driver, err = storage.NewDriver(r.config, r.client)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
 	}
 
 	// Check if bucket needs to be reconciled

--- a/pkg/controller/velero/controller.go
+++ b/pkg/controller/velero/controller.go
@@ -8,9 +8,10 @@ import (
 
 	veleroInstallCR "github.com/openshift/managed-velero-operator/pkg/apis/managed/v1alpha2"
 
+	appsv1 "k8s.io/api/apps/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
-	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/cblecker/platformutils"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -31,13 +32,13 @@ var (
 
 // Add creates a new Velero Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+func Add(mgr manager.Manager, config *configv1.InfrastructureStatus) error {
+	return add(mgr, newReconciler(mgr, config))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileVelero{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+func newReconciler(mgr manager.Manager, config *configv1.InfrastructureStatus) reconcile.Reconciler {
+	return &ReconcileVelero{client: mgr.GetClient(), scheme: mgr.GetScheme(), config: config}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -102,6 +103,7 @@ type ReconcileVelero struct {
 	// that reads objects from the cache and writes to the apiserver
 	client client.Client
 	scheme *runtime.Scheme
+	config *configv1.InfrastructureStatus
 	driver storage.Driver
 }
 

--- a/pkg/controller/velero/controller.go
+++ b/pkg/controller/velero/controller.go
@@ -125,6 +125,10 @@ type VeleroReconciler interface {
 	// CredentialsRequest creates an appropriate CredentialsRequest object for the
 	// cloud platform.
 	CredentialsRequest(namespace, bucketName string) (*minterv1.CredentialsRequest, error)
+
+	// VeleroDeployment creates a base Deployment object with which to deploy Velero
+	// on the cloud platform.
+	VeleroDeployment(namespace string) *appsv1.Deployment
 }
 
 // blank assignment to verify that ReconcileVeleroBase implements reconcile.Reconciler

--- a/pkg/controller/velero/controller.go
+++ b/pkg/controller/velero/controller.go
@@ -14,8 +14,6 @@ import (
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -37,7 +35,7 @@ func Add(mgr manager.Manager, config *configv1.InfrastructureStatus) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, config *configv1.InfrastructureStatus) reconcile.Reconciler {
-	return &ReconcileVelero{client: mgr.GetClient(), scheme: mgr.GetScheme(), config: config}
+	return &ReconcileVeleroBase{client: mgr.GetClient(), scheme: mgr.GetScheme(), config: config}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -93,22 +91,12 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	return nil
 }
 
-// blank assignment to verify that ReconcileVelero implements reconcile.Reconciler
-var _ reconcile.Reconciler = &ReconcileVelero{}
-
-// ReconcileVelero reconciles a Velero object
-type ReconcileVelero struct {
-	// This client, initialized using mgr.Client() above, is a split client
-	// that reads objects from the cache and writes to the apiserver
-	client client.Client
-	scheme *runtime.Scheme
-	config *configv1.InfrastructureStatus
-	driver storage.Driver
-}
+// blank assignment to verify that ReconcileVeleroBase implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileVeleroBase{}
 
 // Reconcile reads that state of the cluster for a Velero object and makes changes based on the state read
 // and what is in the Velero.Spec
-func (r *ReconcileVelero) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+func (r *ReconcileVeleroBase) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling Velero Installation")
 	var err error

--- a/pkg/controller/velero/controller.go
+++ b/pkg/controller/velero/controller.go
@@ -121,6 +121,10 @@ type VeleroReconciler interface {
 
 	// GetLocationConfig returns the Velero BackupStorageLocationSpec.Config field.
 	GetLocationConfig() map[string]string
+
+	// CredentialsRequest creates an appropriate CredentialsRequest object for the
+	// cloud platform.
+	CredentialsRequest(namespace, bucketName string) (*minterv1.CredentialsRequest, error)
 }
 
 // blank assignment to verify that ReconcileVeleroBase implements reconcile.Reconciler

--- a/pkg/controller/velero/controller.go
+++ b/pkg/controller/velero/controller.go
@@ -112,6 +112,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 type VeleroReconciler interface {
 	reconcile.Reconciler
+
+	// RegionInChina returns whether the cloud platform region is in China.
+	RegionInChina() bool
 }
 
 // blank assignment to verify that ReconcileVeleroBase implements reconcile.Reconciler

--- a/pkg/controller/velero/controller.go
+++ b/pkg/controller/velero/controller.go
@@ -118,6 +118,9 @@ type VeleroReconciler interface {
 
 	// GetImageRegistry returns the Velero image registry location.
 	GetImageRegistry() string
+
+	// GetLocationConfig returns the Velero BackupStorageLocationSpec.Config field.
+	GetLocationConfig() map[string]string
 }
 
 // blank assignment to verify that ReconcileVeleroBase implements reconcile.Reconciler

--- a/pkg/controller/velero/controller.go
+++ b/pkg/controller/velero/controller.go
@@ -13,7 +13,6 @@ import (
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 
-	"github.com/cblecker/platformutils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -128,19 +127,9 @@ func (r *ReconcileVelero) Reconcile(request reconcile.Request) (reconcile.Result
 		return reconcile.Result{}, err
 	}
 
-	// Grab infrastructureStatus to determine where OpenShift is installed.
-	pc, err := platformutils.NewClient(context.TODO())
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-	infraStatus, err := pc.GetInfrastructureStatus()
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
 	// Create the Storage Driver
 	if r.driver == nil {
-		r.driver, err = storage.NewDriver(infraStatus, r.client)
+		r.driver, err = storage.NewDriver(r.config, r.client)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -154,5 +143,5 @@ func (r *ReconcileVelero) Reconcile(request reconcile.Request) (reconcile.Result
 	}
 
 	// Now go provision Velero
-	return r.provisionVelero(reqLogger, request.Namespace, infraStatus.PlatformStatus, instance)
+	return r.provisionVelero(reqLogger, request.Namespace, instance)
 }

--- a/pkg/controller/velero/velero.go
+++ b/pkg/controller/velero/velero.go
@@ -30,24 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const (
-	awsCredsSecretIDKey     = "aws_access_key_id"     // #nosec G101
-	awsCredsSecretAccessKey = "aws_secret_access_key" // #nosec G101
-
-	veleroImageRegistry   = "docker.io/velero"
-	veleroImageRegistryCN = "registry.docker-cn.com/velero"
-
-	veleroImageTag    = "velero:v1.3.1"
-	veleroAwsImageTag = "velero-plugin-for-aws:v1.0.1"
-	veleroGcpImageTag = "velero-plugin-for-gcp:v1.0.1"
-
-	credentialsRequestName = "velero-iam-credentials"
-)
-
-var (
-	awsChinaRegions = []string{"cn-north-1", "cn-northwest-1"}
-)
-
 func (r *ReconcileVelero) provisionVelero(reqLogger logr.Logger, namespace string, instance *veleroInstallCR.VeleroInstall) (reconcile.Result, error) {
 	var err error
 

--- a/pkg/controller/velero/velero.go
+++ b/pkg/controller/velero/velero.go
@@ -34,20 +34,8 @@ func (r *ReconcileVeleroBase) provisionVelero(reqLogger logr.Logger, namespace s
 	var err error
 
 	platformType := r.config.PlatformStatus.Type
-
-	var locationConfig map[string]string
-	switch platformType {
-	case configv1.AWSPlatformType:
-		locationConfig = map[string]string{
-			"region": r.config.PlatformStatus.AWS.Region,
-		}
-	case configv1.GCPPlatformType:
-		// No region configuration needed for GCP
-	default:
-		return reconcile.Result{}, fmt.Errorf("unable to determine platform")
-	}
-
 	provider := strings.ToLower(string(platformType))
+	locationConfig := r.vtable.GetLocationConfig()
 
 	// Install BackupStorageLocation
 	foundBsl := &velerov1.BackupStorageLocation{}

--- a/pkg/controller/velero/velero.go
+++ b/pkg/controller/velero/velero.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func (r *ReconcileVelero) provisionVelero(reqLogger logr.Logger, namespace string, instance *veleroInstallCR.VeleroInstall) (reconcile.Result, error) {
+func (r *ReconcileVeleroBase) provisionVelero(reqLogger logr.Logger, namespace string, instance *veleroInstallCR.VeleroInstall) (reconcile.Result, error) {
 	var err error
 
 	platformType := r.config.PlatformStatus.Type

--- a/pkg/controller/velero/velero.go
+++ b/pkg/controller/velero/velero.go
@@ -163,7 +163,7 @@ func (r *ReconcileVeleroBase) provisionVelero(reqLogger logr.Logger, namespace s
 
 	// Install Deployment
 	foundDeployment := &appsv1.Deployment{}
-	deployment := veleroDeployment(namespace, platformType, determineVeleroImageRegistry(platformType, locationConfig["region"]))
+	deployment := veleroDeployment(namespace, platformType, r.vtable.GetImageRegistry())
 	deploymentName, err := runtimeClient.ObjectKeyFromObject(deployment)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -511,20 +511,6 @@ func metricsServiceFromDeployment(deployment *appsv1.Deployment) *corev1.Service
 			SessionAffinity: corev1.ServiceAffinityNone,
 		},
 	}
-}
-
-func determineVeleroImageRegistry(platform configv1.PlatformType, region string) string {
-	if platform == configv1.AWSPlatformType {
-		// Use the image in Chinese mirror if running on AWS China
-		for _, v := range awsChinaRegions {
-			if region == v {
-				return veleroImageRegistryCN
-			}
-		}
-	}
-
-	// Use global image by default
-	return veleroImageRegistry
 }
 
 func credentialsRequestSpecEqual(x, y minterv1.CredentialsRequestSpec) (bool, error) {

--- a/pkg/controller/velero/velero_aws.go
+++ b/pkg/controller/velero/velero_aws.go
@@ -2,10 +2,17 @@ package velero
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 
 	"github.com/openshift/managed-velero-operator/pkg/storage/s3"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	configv1 "github.com/openshift/api/config/v1"
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -41,4 +48,72 @@ func (r *ReconcileVeleroAWS) RegionInChina() bool {
 
 func (r *ReconcileVeleroAWS) GetLocationConfig() map[string]string {
 	return map[string]string{"region": r.config.PlatformStatus.AWS.Region}
+}
+
+func (r *ReconcileVeleroAWS) CredentialsRequest(namespace, bucketName string) (*minterv1.CredentialsRequest, error) {
+	region := r.config.PlatformStatus.AWS.Region
+	partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region)
+	if !ok {
+		return nil, fmt.Errorf("no partition found for region %q", region)
+	}
+
+	resource := fmt.Sprintf("arn:%s:s3:::%s", partition.ID(), bucketName)
+
+	codec, _ := minterv1.NewCodec()
+	providerSpec, _ := codec.EncodeProviderSpec(
+		&minterv1.AWSProviderSpec{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "AWSProviderSpec",
+			},
+			StatementEntries: []minterv1.StatementEntry{
+				{
+					Effect: "Allow",
+					Action: []string{
+						"ec2:DescribeVolumes",
+						"ec2:DescribeSnapshots",
+						"ec2:CreateTags",
+						"ec2:CreateVolume",
+						"ec2:CreateSnapshot",
+						"ec2:DeleteSnapshot",
+					},
+					Resource: "*",
+				},
+				{
+					Effect: "Allow",
+					Action: []string{
+						"s3:GetObject",
+						"s3:DeleteObject",
+						"s3:PutObject",
+						"s3:AbortMultipartUpload",
+						"s3:ListMultipartUploadParts",
+					},
+					Resource: resource + "/*",
+				},
+				{
+					Effect: "Allow",
+					Action: []string{
+						"s3:ListBucket",
+					},
+					Resource: resource,
+				},
+			},
+		})
+
+	return &minterv1.CredentialsRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      credentialsRequestName,
+			Namespace: namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CredentialsRequest",
+			APIVersion: minterv1.SchemeGroupVersion.String(),
+		},
+		Spec: minterv1.CredentialsRequestSpec{
+			SecretRef: corev1.ObjectReference{
+				Name:      credentialsRequestName,
+				Namespace: namespace,
+			},
+			ProviderSpec: providerSpec,
+		},
+	}, nil
 }

--- a/pkg/controller/velero/velero_aws.go
+++ b/pkg/controller/velero/velero_aws.go
@@ -140,5 +140,5 @@ func (r *ReconcileVeleroAWS) VeleroDeployment(namespace string) *appsv1.Deployme
 		veleroInstall.WithImage(
 			imageRegistry + "/" + veleroImageTag))
 
-	return deployment
+	return finishVeleroDeployment(deployment)
 }

--- a/pkg/controller/velero/velero_aws.go
+++ b/pkg/controller/velero/velero_aws.go
@@ -1,0 +1,27 @@
+package velero
+
+import (
+	"context"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// ReconcileVeleroAWS reconciles a Velero object on Amazon Web Services
+type ReconcileVeleroAWS struct {
+	ReconcileVeleroBase
+}
+
+func newReconcileVeleroAWS(ctx context.Context, mgr manager.Manager, config *configv1.InfrastructureStatus) VeleroReconciler {
+	var r = &ReconcileVeleroAWS{
+		ReconcileVeleroBase{
+			client: mgr.GetClient(),
+			scheme: mgr.GetScheme(),
+			config: config,
+		},
+	}
+	r.vtable = r
+
+	return r
+}

--- a/pkg/controller/velero/velero_aws.go
+++ b/pkg/controller/velero/velero_aws.go
@@ -38,3 +38,7 @@ func (r *ReconcileVeleroAWS) RegionInChina() bool {
 	}
 	return false
 }
+
+func (r *ReconcileVeleroAWS) GetLocationConfig() map[string]string {
+	return map[string]string{"region": r.config.PlatformStatus.AWS.Region}
+}

--- a/pkg/controller/velero/velero_aws.go
+++ b/pkg/controller/velero/velero_aws.go
@@ -3,6 +3,8 @@ package velero
 import (
 	"context"
 
+	"github.com/openshift/managed-velero-operator/pkg/storage/s3"
+
 	configv1 "github.com/openshift/api/config/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -22,6 +24,8 @@ func newReconcileVeleroAWS(ctx context.Context, mgr manager.Manager, config *con
 		},
 	}
 	r.vtable = r
+
+	r.driver = s3.NewDriver(ctx, r.config, r.client)
 
 	return r
 }

--- a/pkg/controller/velero/velero_aws.go
+++ b/pkg/controller/velero/velero_aws.go
@@ -29,3 +29,12 @@ func newReconcileVeleroAWS(ctx context.Context, mgr manager.Manager, config *con
 
 	return r
 }
+
+func (r *ReconcileVeleroAWS) RegionInChina() bool {
+	for _, region := range awsChinaRegions {
+		if r.config.PlatformStatus.AWS.Region == region {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/velero/velero_base.go
+++ b/pkg/controller/velero/velero_base.go
@@ -22,3 +22,7 @@ type ReconcileVeleroBase struct {
 	config *configv1.InfrastructureStatus
 	driver storage.Driver
 }
+
+func (r *ReconcileVeleroBase) RegionInChina() bool {
+	return false
+}

--- a/pkg/controller/velero/velero_base.go
+++ b/pkg/controller/velero/velero_base.go
@@ -12,6 +12,9 @@ import (
 // ReconcileVeleroBase reconciles a Velero object.  It serves as an "abstract"
 // base struct for embedding in other cloud-platform-specific structs.
 type ReconcileVeleroBase struct {
+	// virtual method table
+	vtable VeleroReconciler
+
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
 	client client.Client

--- a/pkg/controller/velero/velero_base.go
+++ b/pkg/controller/velero/velero_base.go
@@ -26,3 +26,10 @@ type ReconcileVeleroBase struct {
 func (r *ReconcileVeleroBase) RegionInChina() bool {
 	return false
 }
+
+func (r *ReconcileVeleroBase) GetImageRegistry() string {
+	if r.vtable.RegionInChina() {
+		return veleroImageRegistryCN
+	}
+	return veleroImageRegistry
+}

--- a/pkg/controller/velero/velero_base.go
+++ b/pkg/controller/velero/velero_base.go
@@ -4,6 +4,7 @@ import (
 	"github.com/openshift/managed-velero-operator/pkg/storage"
 
 	configv1 "github.com/openshift/api/config/v1"
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,4 +37,9 @@ func (r *ReconcileVeleroBase) GetImageRegistry() string {
 
 func (r *ReconcileVeleroBase) GetLocationConfig() map[string]string {
 	return nil
+}
+
+func (r *ReconcileVeleroBase) CredentialsRequest(namespace, bucketName string) (*minterv1.CredentialsRequest, error) {
+	// This method should always be overridden.
+	panic("VeleroReconciler.CredentialsRequest not implemented")
 }

--- a/pkg/controller/velero/velero_base.go
+++ b/pkg/controller/velero/velero_base.go
@@ -33,3 +33,7 @@ func (r *ReconcileVeleroBase) GetImageRegistry() string {
 	}
 	return veleroImageRegistry
 }
+
+func (r *ReconcileVeleroBase) GetLocationConfig() map[string]string {
+	return nil
+}

--- a/pkg/controller/velero/velero_base.go
+++ b/pkg/controller/velero/velero_base.go
@@ -1,0 +1,21 @@
+package velero
+
+import (
+	"github.com/openshift/managed-velero-operator/pkg/storage"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ReconcileVeleroBase reconciles a Velero object.  It serves as an "abstract"
+// base struct for embedding in other cloud-platform-specific structs.
+type ReconcileVeleroBase struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+	config *configv1.InfrastructureStatus
+	driver storage.Driver
+}

--- a/pkg/controller/velero/velero_base.go
+++ b/pkg/controller/velero/velero_base.go
@@ -3,6 +3,7 @@ package velero
 import (
 	"github.com/openshift/managed-velero-operator/pkg/storage"
 
+	appsv1 "k8s.io/api/apps/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 
@@ -42,4 +43,9 @@ func (r *ReconcileVeleroBase) GetLocationConfig() map[string]string {
 func (r *ReconcileVeleroBase) CredentialsRequest(namespace, bucketName string) (*minterv1.CredentialsRequest, error) {
 	// This method should always be overridden.
 	panic("VeleroReconciler.CredentialsRequest not implemented")
+}
+
+func (r *ReconcileVeleroBase) VeleroDeployment(namespace string) *appsv1.Deployment {
+	// This method should always be overridden.
+	panic("VeleroReconciler.VeleroDeployment not implemented")
 }

--- a/pkg/controller/velero/velero_gcp.go
+++ b/pkg/controller/velero/velero_gcp.go
@@ -5,7 +5,11 @@ import (
 
 	"github.com/openshift/managed-velero-operator/pkg/storage/gcs"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	configv1 "github.com/openshift/api/config/v1"
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -28,4 +32,38 @@ func newReconcileVeleroGCP(ctx context.Context, mgr manager.Manager, config *con
 	r.driver = gcs.NewDriver(ctx, r.config, r.client)
 
 	return r
+}
+
+func (r *ReconcileVeleroGCP) CredentialsRequest(namespace, bucketName string) (*minterv1.CredentialsRequest, error) {
+	codec, _ := minterv1.NewCodec()
+	providerSpec, _ := codec.EncodeProviderSpec(
+		&minterv1.GCPProviderSpec{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "GCPProviderSpec",
+			},
+			PredefinedRoles: []string{
+				"roles/compute.storageAdmin",
+				"roles/iam.serviceAccountUser",
+				"roles/cloudmigration.storageaccess",
+			},
+			SkipServiceCheck: true,
+		})
+
+	return &minterv1.CredentialsRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      credentialsRequestName,
+			Namespace: namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CredentialsRequest",
+			APIVersion: minterv1.SchemeGroupVersion.String(),
+		},
+		Spec: minterv1.CredentialsRequestSpec{
+			SecretRef: corev1.ObjectReference{
+				Name:      credentialsRequestName,
+				Namespace: namespace,
+			},
+			ProviderSpec: providerSpec,
+		},
+	}, nil
 }

--- a/pkg/controller/velero/velero_gcp.go
+++ b/pkg/controller/velero/velero_gcp.go
@@ -113,5 +113,5 @@ func (r *ReconcileVeleroGCP) VeleroDeployment(namespace string) *appsv1.Deployme
 		}...
 	)
 
-	return deployment
+	return finishVeleroDeployment(deployment)
 }

--- a/pkg/controller/velero/velero_gcp.go
+++ b/pkg/controller/velero/velero_gcp.go
@@ -3,6 +3,8 @@ package velero
 import (
 	"context"
 
+	"github.com/openshift/managed-velero-operator/pkg/storage/gcs"
+
 	configv1 "github.com/openshift/api/config/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -22,6 +24,8 @@ func newReconcileVeleroGCP(ctx context.Context, mgr manager.Manager, config *con
 		},
 	}
 	r.vtable = r
+
+	r.driver = gcs.NewDriver(ctx, r.config, r.client)
 
 	return r
 }

--- a/pkg/controller/velero/velero_gcp.go
+++ b/pkg/controller/velero/velero_gcp.go
@@ -1,0 +1,27 @@
+package velero
+
+import (
+	"context"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// ReconcileVeleroGCP reconciles a Velero object on Google Cloud Platform
+type ReconcileVeleroGCP struct {
+	ReconcileVeleroBase
+}
+
+func newReconcileVeleroGCP(ctx context.Context, mgr manager.Manager, config *configv1.InfrastructureStatus) VeleroReconciler {
+	var r = &ReconcileVeleroGCP{
+		ReconcileVeleroBase{
+			client: mgr.GetClient(),
+			scheme: mgr.GetScheme(),
+			config: config,
+		},
+	}
+	r.vtable = r
+
+	return r
+}

--- a/pkg/controller/velero/velero_test.go
+++ b/pkg/controller/velero/velero_test.go
@@ -1,0 +1,583 @@
+package velero
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// MockManager mocks the controller-runtime Manager interface.
+type MockManager struct {}
+
+func (m *MockManager) Add(manager.Runnable) error {
+	return nil
+}
+
+func (m *MockManager) Elected() <-chan struct{} {
+	return nil
+}
+
+func (m *MockManager) SetFields(interface{}) error {
+	return nil
+}
+
+func (m *MockManager) AddMetricsExtraHandler(path string, handler http.Handler) error {
+	return nil
+}
+
+func (m *MockManager) AddHealthzCheck(name string, check healthz.Checker) error {
+	return nil
+}
+
+func (m *MockManager) AddReadyzCheck(name string, check healthz.Checker) error {
+	return nil
+}
+
+func (m *MockManager) Start(<-chan struct{}) error {
+	return nil
+}
+
+func (m *MockManager) GetConfig() *rest.Config {
+	return nil
+}
+
+func (m *MockManager) GetScheme() *runtime.Scheme {
+	return nil
+}
+
+func (m *MockManager) GetClient() client.Client {
+	return nil
+}
+
+func (m *MockManager) GetFieldIndexer() client.FieldIndexer {
+	return nil
+}
+
+func (m *MockManager) GetCache() cache.Cache {
+	return nil
+}
+
+func (m *MockManager) GetEventRecorderFor(name string) record.EventRecorder {
+	return nil
+}
+
+func (m *MockManager) GetRESTMapper() meta.RESTMapper {
+	return nil
+}
+
+func (m *MockManager) GetAPIReader() client.Reader {
+	return nil
+}
+
+func (m *MockManager) GetWebhookServer() *webhook.Server {
+	return nil
+}
+
+var (
+)
+
+func TestVeleroReconciler(t *testing.T) {
+	var mgr manager.Manager = &MockManager{}
+
+	// AWS Regions: https://docs.aws.amazon.com/general/latest/gr/rande.html
+	// GCP Regions: https://cloud.google.com/compute/docs/regions-zones/#locations
+	var tests = []struct {
+		config             *configv1.InfrastructureStatus
+		wantErr            bool
+		wantRegionInChina  bool
+		wantLocationConfig map[string]string
+	}{
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.NonePlatformType,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "us-east-2",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "us-east-2"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "us-east-1",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "us-east-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "us-west-1",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "us-west-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "us-west-2",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "us-west-2"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "af-south-1",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "af-south-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "ap-east-1",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "ap-east-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "ap-south-1",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "ap-south-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "ap-northeast-3",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "ap-northeast-3"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "ap-northeast-2",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "ap-northeast-2"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "ap-southeast-1",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "ap-southeast-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "ap-southeast-2",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "ap-southeast-2"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "ap-northeast-1",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "ap-northeast-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "ca-central-1",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "ca-central-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "cn-north-1",
+					},
+				},
+			},
+			wantRegionInChina: true,
+			wantLocationConfig: map[string]string {"region": "cn-north-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "cn-northwest-1",
+					},
+				},
+			},
+			wantRegionInChina: true,
+			wantLocationConfig: map[string]string {"region": "cn-northwest-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "eu-central-1",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "eu-central-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "eu-west-1",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "eu-west-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "eu-west-2",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "eu-west-2"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "eu-south-1",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "eu-south-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "eu-west-3",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "eu-west-3"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "eu-north-1",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "eu-north-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "me-south-1",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "me-south-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+					AWS: &configv1.AWSPlatformStatus{
+						Region: "sa-east-1",
+					},
+				},
+			},
+			wantLocationConfig: map[string]string {"region": "sa-east-1"},
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.GCPPlatformType,
+					GCP: &configv1.GCPPlatformStatus{
+						Region: "asia-east1",
+					},
+				},
+			},
+			wantLocationConfig: nil,
+			// FIXME wantRegionInChina: ??? (Taiwan)
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.GCPPlatformType,
+					GCP: &configv1.GCPPlatformStatus{
+						Region: "asia-east2",
+					},
+				},
+			},
+			wantLocationConfig: nil,
+			// FIXME wantRegionInChina: true (Hong Kong)
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.GCPPlatformType,
+					GCP: &configv1.GCPPlatformStatus{
+						Region: "asia-northeast1",
+					},
+				},
+			},
+			wantLocationConfig: nil,
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.GCPPlatformType,
+					GCP: &configv1.GCPPlatformStatus{
+						Region: "asia-northeast2",
+					},
+				},
+			},
+			wantLocationConfig: nil,
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.GCPPlatformType,
+					GCP: &configv1.GCPPlatformStatus{
+						Region: "asia-northeast3",
+					},
+				},
+			},
+			wantLocationConfig: nil,
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.GCPPlatformType,
+					GCP: &configv1.GCPPlatformStatus{
+						Region: "asia-south1",
+					},
+				},
+			},
+			wantLocationConfig: nil,
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.GCPPlatformType,
+					GCP: &configv1.GCPPlatformStatus{
+						Region: "asia-southeast1",
+					},
+				},
+			},
+			wantLocationConfig: nil,
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.GCPPlatformType,
+					GCP: &configv1.GCPPlatformStatus{
+						Region: "australia-southeast1",
+					},
+				},
+			},
+			wantLocationConfig: nil,
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.GCPPlatformType,
+					GCP: &configv1.GCPPlatformStatus{
+						Region: "europe-north1",
+					},
+				},
+			},
+			wantLocationConfig: nil,
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.GCPPlatformType,
+					GCP: &configv1.GCPPlatformStatus{
+						Region: "europe-west1",
+					},
+				},
+			},
+			wantLocationConfig: nil,
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.GCPPlatformType,
+					GCP: &configv1.GCPPlatformStatus{
+						Region: "europe-west2",
+					},
+				},
+			},
+			wantLocationConfig: nil,
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.GCPPlatformType,
+					GCP: &configv1.GCPPlatformStatus{
+						Region: "europe-west3",
+					},
+				},
+			},
+			wantLocationConfig: nil,
+		},
+		{
+			config: &configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.GCPPlatformType,
+					GCP: &configv1.GCPPlatformStatus{
+						Region: "europe-west4",
+					},
+				},
+			},
+			wantLocationConfig: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		var name string
+
+		switch tt.config.PlatformStatus.Type {
+		case configv1.AWSPlatformType:
+			name = fmt.Sprintf("aws-%s", tt.config.PlatformStatus.AWS.Region)
+		case configv1.GCPPlatformType:
+			name = fmt.Sprintf("gcp-%s", tt.config.PlatformStatus.GCP.Region)
+		default:
+			name = fmt.Sprintf("Unsupported platform (%s)", tt.config.PlatformStatus.Type)
+		}
+
+		t.Run(name, func(t *testing.T) {
+			r, err := newVeleroReconciler(mgr, tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newVeleroReconciler() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+
+			switch tt.config.PlatformStatus.Type {
+			case configv1.AWSPlatformType:
+				if _, ok := r.(*ReconcileVeleroAWS); !ok {
+					t.Errorf("newVeleroReconciler() produced a %T, wanted *velero.ReconcileVeleroAWS", r)
+				}
+			case configv1.GCPPlatformType:
+				if _, ok := r.(*ReconcileVeleroGCP); !ok {
+					t.Errorf("newVeleroReconciler() produced a %t, wanted *velero.ReconcileVeleroGCP", r)
+				}
+			}
+
+			regionInChina := r.RegionInChina()
+			if regionInChina != tt.wantRegionInChina {
+				t.Errorf("RegionInChina() returned %t, wanted %t", regionInChina, tt.wantRegionInChina)
+			}
+
+			imageRegistry := r.GetImageRegistry()
+			if !tt.wantRegionInChina && imageRegistry != veleroImageRegistry {
+				t.Errorf("GetImageRegistry() returned %s, wanted %s", imageRegistry, veleroImageRegistry)
+			} else if tt.wantRegionInChina && imageRegistry != veleroImageRegistryCN {
+				t.Errorf("GetImageRegistry() returned %s, wanted %s", imageRegistry, veleroImageRegistryCN)
+			}
+
+			locationConfig := r.GetLocationConfig()
+			if !reflect.DeepEqual(locationConfig, tt.wantLocationConfig) {
+				t.Errorf("GetLocationConfig() returned %v, wanted %v", locationConfig, tt.wantLocationConfig)
+			}
+
+			credentialsRequest, err := r.CredentialsRequest("namespace", "bucket")
+			if err != nil {
+				t.Errorf("CredentialsRequest() failed: %v", err)
+			} else {
+				var object runtime.Object
+
+				// Test that we can decode the ProviderSpec.
+				codec, _ := minterv1.NewCodec()
+				switch tt.config.PlatformStatus.Type {
+				case configv1.AWSPlatformType:
+					object = &minterv1.AWSProviderSpec{}
+				case configv1.GCPPlatformType:
+					object = &minterv1.GCPProviderSpec{}
+				}
+				if err = codec.DecodeProviderSpec(credentialsRequest.Spec.ProviderSpec, object); err != nil {
+					t.Errorf("Unable to decode ProviderSpec for CredentialsRequest: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -25,20 +25,10 @@ func NewDriver(cfg *configv1.InfrastructureStatus, client client.Client) (Driver
 
 	ctx := context.Background()
 
-	// Verify that we have received the needed platform information
 	switch cfg.PlatformStatus.Type {
 	case configv1.AWSPlatformType:
-		if cfg.PlatformStatus.AWS == nil ||
-			len(cfg.PlatformStatus.AWS.Region) < 1 {
-			return nil, fmt.Errorf("unable to determine AWS region")
-		}
 		driver = s3.NewDriver(ctx, cfg, client)
 	case configv1.GCPPlatformType:
-		if cfg.PlatformStatus.GCP == nil ||
-			len(cfg.PlatformStatus.GCP.Region) < 1 ||
-			len(cfg.PlatformStatus.GCP.ProjectID) < 1 {
-			return nil, fmt.Errorf("unable to determine GCP region")
-		}
 		driver = gcs.NewDriver(ctx, cfg, client)
 	default:
 		return nil, fmt.Errorf("unable to determine platform")

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -1,15 +1,9 @@
 package storage
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 	veleroInstallCR "github.com/openshift/managed-velero-operator/pkg/apis/managed/v1alpha2"
-	"github.com/openshift/managed-velero-operator/pkg/storage/gcs"
-	"github.com/openshift/managed-velero-operator/pkg/storage/s3"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 //Driver interface to be satisfied by all present and future storage cloud providers
@@ -17,22 +11,4 @@ type Driver interface {
 	GetPlatformType() configv1.PlatformType
 	CreateStorage(logr.Logger, *veleroInstallCR.VeleroInstall) error
 	StorageExists(string) (bool, error)
-}
-
-//NewDriver will return a driver object
-func NewDriver(cfg *configv1.InfrastructureStatus, client client.Client) (Driver, error) {
-	var driver Driver
-
-	ctx := context.Background()
-
-	switch cfg.PlatformStatus.Type {
-	case configv1.AWSPlatformType:
-		driver = s3.NewDriver(ctx, cfg, client)
-	case configv1.GCPPlatformType:
-		driver = gcs.NewDriver(ctx, cfg, client)
-	default:
-		return nil, fmt.Errorf("unable to determine platform")
-	}
-
-	return driver, nil
 }


### PR DESCRIPTION
This is a rework of commits that didn't make the cut for #60.

This time the platform-specific logic is kept in the `velero` package instead of polluting the storage drivers.

There's also new tests that exercise the reconciler helper methods for all AWS and GCP regions.