### PR TITLE
Only include "replaces:" field if a previous version was provided

### DIFF
--- a/hack/generate-operator-bundle.py
+++ b/hack/generate-operator-bundle.py
@@ -136,7 +136,9 @@ csv['spec']['install']['spec']['deployments'][0]['spec']['template']['spec']['co
 # Update the versions to include git hash:
 csv['metadata']['name'] = "{}.v{}".format(OPERATOR_NAME, full_version)
 csv['spec']['version'] = full_version
-csv['spec']['replaces'] = "{}.v{}".format(OPERATOR_NAME, prev_version)
+# Only include "replaces" field if a previous version was provided
+if prev_version:
+    csv['spec']['replaces'] = "{}.v{}".format(OPERATOR_NAME, prev_version)
 
 # Set the CSV createdAt annotation:
 now = datetime.datetime.now()


### PR DESCRIPTION
The "replaces" field on the CSV currently doesn't populate correctly because there is no previous version to refer to. This changes the generator to only include that field is a previous version was provided. 