### PR TITLE
Removing the optional 'required CRDs' entry

### DIFF
--- a/hack/generate-operator-bundle.py
+++ b/hack/generate-operator-bundle.py
@@ -69,18 +69,6 @@ for file_name in crd_files:
         }
     )
 
-csv['spec']['customresourcedefinitions']['required'] = []
-
-# Add CredentialRequest as a required CRD.
-csv['spec']['customresourcedefinitions']['required'].append(
-    {
-        "name": "credentialsrequests.cloudcredential.openshift.io",
-        "version": "v1",
-        "kind": "CredentialsRequest",
-        "displayName": "CredentialsRequest",
-        "description": "CredentialsRequest",
-    })
-
 # Copy all prometheus yaml files over to the bundle output dir:
 prom_files = [ f for f in os.listdir('deploy') if f.startswith('prometheus_') ]
 for file_name in prom_files:


### PR DESCRIPTION
The 'required CRDs' portion of the CSV is optional and I suspect it is what is blocking me from creating an InstallPlan when testing this deployment.  Additional details on this field are here: https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#required-crds