### PR TITLE
Fix indentation on serviceaccount name in old-artifacts-template.yaml

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -37,8 +37,8 @@ objects:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
-      name: velero
-      namespace: openshift-velero
+        name: velero
+        namespace: openshift-velero
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:


### PR DESCRIPTION
This indents the `name` and `namespace` fields for the velero service account resource. 