### PR TITLE
Update create_image_catalog script to check app-interface for latest deployed prod hash

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -27,8 +27,8 @@ git clone \
 REMOVED_VERSIONS=""
 if [[ "$REMOVE_UNDEPLOYED" == true ]]; then
     DEPLOYED_HASH=$(
-        curl -s "https://gitlab.cee.redhat.com/service/saas-osd-operators/raw/master/${_OPERATOR_NAME}-services/${_OPERATOR_NAME}.yaml" | \
-            docker run --rm -i evns/yq -r '.services[]|select(.name="${_OPERATOR_NAME}").hash'
+        curl -s "https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-${_OPERATOR_NAME}.yaml" | \
+        docker run --rm -i evns/yq -r '.resourceTemplates[]|select(.name="managed-velero-operator").targets[]|select(.namespace["$ref"]=="/services/osd-operators/namespaces/hive-production-cluster-scope.yml")|.ref'
     )
 
     delete=false


### PR DESCRIPTION
The recent migration from saasherder to app-interface means that create_image_catalog scripts will need to check for the latest deployed hash in a new location. This PR updates the URL and yq command to find the hash deployed to production in the new yaml format. 