### PR TITLE
 Use 'hive.openshift.io/v1' as apiVersion for SSS

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -14,7 +14,7 @@ parameters:
 metadata:
   name: selectorsyncset-template
 objects:
-- apiVersion: hive.openshift.io/v1alpha1
+- apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
     labels:


### PR DESCRIPTION
Update the apiVersion for the selectorsyncset to 'hive.openshift.io/v1' so that can be applied to the new v4 hive shards. 