### PR TITLE
Remove temporary nonstandard make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,6 @@ generate: op-generate openapi-generate go-generate
 
 # << TEMPORARY <<
 
-# >> TEMPORARY >>
-# Remove this section once prow configuration is standardized.
-.PHONY: verify
-verify: lint
-# << TEMPORARY <<
-
 .PHONY: boilerplate-update
 boilerplate-update:
 	@boilerplate/update


### PR DESCRIPTION
https://github.com/openshift/release/pull/13776 standardized prow to use boilerplate's target names for CI jobs, so we no longer need to alias `lint` to `verify`.