### PR TITLE
Update aws client to use shared creds file

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -49,9 +49,9 @@ spec:
             - name: bound-sa-token
               mountPath: /var/run/secrets/openshift/serviceaccount          
       volumes:
-        - name: bound-sa-token
+      - name: bound-sa-token
         projected:
           sources:
           - serviceAccountToken:
-            path: token
-            audience: openshift
+              path: token
+              audience: openshift

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -45,3 +45,13 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "managed-velero-operator"
+          volumeMounts:
+            - name: bound-sa-token
+              mountPath: /var/run/secrets/openshift/serviceaccount          
+      volumes:
+        - name: bound-sa-token
+        projected:
+          sources:
+          - serviceAccountToken:
+            path: token
+            audience: openshift

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.42.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.6.1 // indirect
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602
 	google.golang.org/api v0.44.0
 	k8s.io/api v0.20.0

--- a/go.mod
+++ b/go.mod
@@ -17,10 +17,10 @@ require (
 	github.com/cblecker/platformutils v0.0.0-20200321191645-443abe7fea11
 	github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8
 	github.com/operator-framework/operator-sdk v0.18.2
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.42.1
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.6.1 // indirect
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602
 	google.golang.org/api v0.44.0
 	k8s.io/api v0.20.0

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/cblecker/platformutils v0.0.0-20200321191645-443abe7fea11
 	github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8
 	github.com/operator-framework/operator-sdk v0.18.2
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.42.1
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602

--- a/pkg/controller/velero/velero.go
+++ b/pkg/controller/velero/velero.go
@@ -30,9 +30,6 @@ import (
 )
 
 const (
-	awsCredsSecretIDKey     = "aws_access_key_id"     // #nosec G101
-	awsCredsSecretAccessKey = "aws_secret_access_key" // #nosec G101
-
 	veleroImageRegistry   = "docker.io/velero"
 	veleroImageRegistryCN = "registry.docker-cn.com/velero"
 
@@ -309,7 +306,7 @@ func veleroDeployment(namespace string, platform configv1.PlatformType, veleroIm
 				Name: "cloud-credentials",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName:  awsCredsSecretName, //make sharedcredsfile secret
+						SecretName:  awsCredsSecretName,
 						DefaultMode: &defaultMode,
 					},
 				},

--- a/pkg/storage/s3/shared_credentials_file.go
+++ b/pkg/storage/s3/shared_credentials_file.go
@@ -1,0 +1,59 @@
+package s3
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// SharedCredentialsFileFromSecret returns a path to the shared creds file created using provided secret
+// configure the aws session using file to use credentials eg
+// sharedCredentialsFile, err := SharedCredentialsFileFromSecret(secret)
+// if err != nil {
+// 	// handle error
+// }
+// options := session.Options{
+// 	SharedConfigState: session.SharedConfigEnable,
+// 	SharedConfigFiles: []string{sharedCredentialsFile},
+// }
+// sess := session.Must(session.NewSessionWithOptions(options))
+func SharedCredentialsFileFromSecret(secret *corev1.Secret) (string, error) {
+	var data []byte
+	switch {
+	case len(secret.Data["credentials"]) > 0:
+		data = secret.Data["credentials"]
+	case len(secret.Data["aws_access_key_id"]) > 0 && len(secret.Data["aws_secret_access_key"]) > 0:
+		data = newConfigForStaticCreds(
+			string(secret.Data["aws_access_key_id"]),
+			string(secret.Data["aws_secret_access_key"]),
+		)
+
+	default:
+		return "", errors.New("invalid secret for aws credentials")
+
+	}
+
+	f, err := ioutil.TempFile("", "aws-shared-credentials")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create file for shared credentials")
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		return "", errors.Wrapf(err, "failed to write credentials to %s", f.Name())
+	}
+
+	return f.Name(), nil
+
+}
+
+func newConfigForStaticCreds(accessKey string, accessSecret string) []byte {
+	buf := &bytes.Buffer{}
+	fmt.Fprint(buf, "[default]\n")
+	fmt.Fprintf(buf, "aws_access_key_id = %s\n", accessKey)
+	fmt.Fprintf(buf, "aws_secret_access_key = %s\n", accessSecret)
+	return buf.Bytes()
+}

--- a/pkg/storage/s3/shared_credentials_file_test.go
+++ b/pkg/storage/s3/shared_credentials_file_test.go
@@ -1,0 +1,108 @@
+package s3
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestNewConfigForStaticCreds(t *testing.T) {
+	cases := []struct {
+		key          string
+		secret       string
+		sharedConfig string
+	}{{
+		key:    `asdf`,
+		secret: `asdf1234`,
+		sharedConfig: `[default]
+aws_access_key_id = asdf
+aws_secret_access_key = asdf1234
+`,
+	}}
+
+	for _, test := range cases {
+		t.Run("", func(t *testing.T) {
+			sharedConfig := newConfigForStaticCreds(test.key, test.secret)
+			assert.Equal(t, string(sharedConfig), test.sharedConfig)
+		})
+	}
+}
+
+func TestSharedCredentialsFileFromSecret(t *testing.T) {
+	cases := []struct {
+		data         map[string]string
+		sharedConfig string
+		err          string
+	}{{
+		data: map[string]string{
+			"aws_access_key_id":     "asdf",
+			"aws_secret_access_key": "asdf1234",
+		},
+		sharedConfig: `[default]
+aws_access_key_id = asdf
+aws_secret_access_key = asdf1234
+`,
+	}, {
+		data: map[string]string{
+			"credentials": `[default]
+assume_role = role_for_managed_velero_operator
+web_identity_token = /path/to/sa/token
+`,
+		},
+
+		sharedConfig: `[default]
+assume_role = role_for_managed_velero_operator
+web_identity_token = /path/to/sa/token
+`,
+	}, {
+		data: map[string]string{
+			"wrong_format_cred_file": "random_value",
+		},
+		// err should match the defaut case for SharedCredentialsFileFromSecret() func
+		// and return the exact same error message of `invalid secret for aws credentials`
+		err: "invalid secret for aws credentials",
+	}, {
+		data: map[string]string{
+			"aws_access_key_id":     "asdf",
+			"aws_secret_access_key": "asdf1234",
+			"credentials": `[default]
+aws_access_key_id = asdf
+aws_secret_access_key = asdf1234
+`,
+		},
+		sharedConfig: `[default]
+aws_access_key_id = asdf
+aws_secret_access_key = asdf1234
+`,
+	}}
+
+	for _, test := range cases {
+		t.Run("", func(t *testing.T) {
+			secret := &corev1.Secret{
+				Data: map[string][]byte{},
+			}
+
+			for k, v := range test.data {
+				secret.Data[k] = []byte(v)
+			}
+
+			credPath, err := SharedCredentialsFileFromSecret(secret)
+			if credPath != "" {
+				defer os.Remove(credPath)
+			}
+
+			if test.err == "" {
+				assert.NoError(t, err)
+				data, err := ioutil.ReadFile(credPath)
+				t.Log(data)
+				assert.NoError(t, err)
+				assert.Equal(t, string(data), test.sharedConfig)
+			} else {
+				assert.Regexp(t, test.err, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements the AWS SDK's default handling of shared credentials file. Currently, this operator only supports static credentials from the aws_access_key_id and aws_secret_access_key in the aws secret.

This PR adds in support for another style of authentication by reading 'credentials' key to load shared credential file and use this to authenticate with AWS. 