### PR TITLE
Disable velero on sts mode

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -35,6 +35,11 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - "true"
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
Disable the managed-velero-operator when cluster is created in sts mode.

Note: This change is temporary while we work on implementing sts creds for the operator.