### PR TITLE
Replace conversion spec modifications

### DIFF
--- a/pkg/velero/crds.go
+++ b/pkg/velero/crds.go
@@ -26,6 +26,11 @@ func InstallVeleroCRDs(log logr.Logger, client client.Client) error {
 			return err
 		}
 
+		// Add Conversion to the spec, as this will be returned in the founcCrd
+		crd.Spec.Conversion = &apiv1.CustomResourceConversion{
+			Strategy: apiv1.NoneConverter,
+		}
+
 		// Lookup for installed/pre-existing crds
 		foundCrd := &apiv1.CustomResourceDefinition{}
 		if err = client.Get(context.TODO(), types.NamespacedName{Name: crd.ObjectMeta.Name}, foundCrd); err != nil {


### PR DESCRIPTION
ref https://github.com/openshift/managed-velero-operator/pull/132#discussion_r693180057

This stanza was removed incorrectly. Right now the CRDs are being updated each time the container boots, no matter if it's needed or not. This fixes that comparison.

/assign @boranx 