### PR TITLE
We need use the ubi minimal image, since micro does not has root CA

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-micro:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV USER_UID=1001 \
     USER_NAME=managed-velero-operator


### PR DESCRIPTION
Because the micro image doesn't has root CA files, I see the following errors on stg env:
```
{"level":"error","ts":1646361657.3095574,"logger":"controller.velero-controller","msg":"Reconciler error","name":"cluster","namespace":"openshift-velero","error":"RequestError: send request failed\ncaused by: Get \"https://s3.amazonaws.com/\": x509: certificate signed by unknown authority","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.10.2/pkg/internal/controller/controller.go:227"}
```