### PR TITLE
Use trusted CA when accessing urls

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -45,3 +45,15 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "managed-velero-operator"
+          volumeMounts:
+          - mountPath: /etc/pki/ca-trust/extracted/pem
+            name: trusted-ca-bundle
+            readOnly: true
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
+          name: trusted-ca-bundle
+        name: trusted-ca-bundle

--- a/deploy/trusted_ca_bundle_configmap.yaml
+++ b/deploy/trusted_ca_bundle_configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-velero
+  name: trusted-ca-bundle
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"


### PR DESCRIPTION
When debugging a cluster, found that some calls via the AWS SDK weren't using a trusted CA bundle. This should allow it for the operator.