### PR TITLE
Add trusted-ca bundle to subscription and to velero deployment

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -46,14 +46,13 @@ spec:
             - name: OPERATOR_NAME
               value: "managed-velero-operator"
           volumeMounts:
-          - mountPath: /etc/pki/ca-trust/extracted/pem
-            name: trusted-ca-bundle
+          - name: trusted-ca-bundle
+            mountPath: /etc/pki/ca-trust/extracted/pem
             readOnly: true
       volumes:
-      - configMap:
-          defaultMode: 420
+      - name: trusted-ca-bundle
+        configMap:
+          name: trusted-ca-bundle
           items:
             - key: ca-bundle.crt
               path: tls-ca-bundle.pem
-          name: trusted-ca-bundle
-        name: trusted-ca-bundle

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -169,6 +169,18 @@ objects:
         name: managed-velero-operator
         source: managed-velero-operator-registry
         sourceNamespace: openshift-velero
+        config:
+          volumes:
+          - name: trusted-ca-bundle
+            configMap:
+              name: trusted-ca-bundle
+              items:
+                - key: ca-bundle.crt
+                  path: tls-ca-bundle.pem
+          volumeMounts:
+          - name: trusted-ca-bundle
+            mountPath: /etc/pki/ca-trust/extracted/pem
+            readOnly: true
     - apiVersion: operators.coreos.com/v1alpha2
       kind: OperatorGroup
       metadata:


### PR DESCRIPTION
#143 added this to the deployment.yaml, but that didn't actually get consumed by the subscription. This adds the volumes to the subscription and velero deployment