### PR TITLE
Disable dependabot for boilerplate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,6 @@ updates:
       - "ok-to-test"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "quay.io/app-sre/boilerplate"
+        # don't upgrade boilerplate via these means


### PR DESCRIPTION
Disables dependabot for boilerplate, as we update this via other means