### PR TITLE
Fix boilerplate image name and change cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       - "area/dependency"
       - "ok-to-test"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     ignore:
       - dependency-name: "app-sre/boilerplate"
         # don't upgrade boilerplate via these means

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,5 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "quay.io/app-sre/boilerplate"
+      - dependency-name: "app-sre/boilerplate"
         # don't upgrade boilerplate via these means


### PR DESCRIPTION
Got the application name wrong. Confirmed in logs:
```
updater | INFO <job_523659470> Checking if app-sre/boilerplate image-v2.3.2 needs updating
  proxy | 2022/11/23 16:27:52 [020] GET https://quay.io:443/v2/app-sre/boilerplate/tags/list
  proxy | 2022/11/23 16:27:52 [020] 200 https://quay.io:443/v2/app-sre/boilerplate/tags/list
updater | INFO <job_523659470> Latest version is image-v3.0.2
updater | INFO <job_523659470> Pull request already exists for app-sre/boilerplate with latest version image-v3.0.2
```

So hopefully this will now ignore it

Also changes the frequency to weekly