### PR TITLE
Remove `apiextensions.k8s.io/v1beta1` usage

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,11 +35,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -148,7 +148,7 @@ func main() {
 	}
 
 	// Add Custom Resource apis to scheme
-	if err := apiextv1beta1.AddToScheme(mgr.GetScheme()); err != nil {
+	if err := apiextv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Noticed in [OSD-14249](https://issues.redhat.com//browse/OSD-14249), `apiextensions.k8s.io/v1beta1` was [removed in K8s v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) and no longer served.

It's only usage in the operator codebase was on startup when registering it with the operator's scheme. In `pkg/velero/crds.go` it had been using the apiextensions/v1 api already anyway