### PR TITLE
Set two service settings that should be set on generation

### DIFF
--- a/main.go
+++ b/main.go
@@ -223,6 +223,8 @@ func getWatchNamespace() (string, error) {
 func addMetrics(ctx context.Context, cl crclient.Client, cfg *rest.Config) error {
 	foundService := &corev1.Service{}
 	service, err := opmetrics.GenerateService(metricsPort, "http-metrics", OperatorName+"-metrics", ManagedVeleroOperatorNamespace, map[string]string{"name": OperatorName})
+	service.Spec.SessionAffinity = corev1.ServiceAffinityNone // Set session affinity to None (default)
+	service.Spec.Type = corev1.ServiceTypeClusterIP           // Set service type to ClusterIP (default)
 	if err != nil {
 		log.Error(err, "Could not generate metrics service")
 		return err


### PR DESCRIPTION
SessionAffinity and Type should be set on service generation but are not. This means it will run a no-op update every time operator boots. This isn't a huge deal, but this small change fixes it.