### PR TITLE
Allow opt-out of velero operator

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -33,8 +33,15 @@ objects:
     name: managed-velero-operator
   spec:
     clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/managed
+        operator: In
+        values:
+        - 'true'
+      - key: ext-velero.managed.openshift.io/enabled
+        operator: NotIn
+        values:
+        - 'false'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
Non-STS OSD/ROSA customers cannot install OADP.
See example: https://issues.redhat.com/browse/OHSS-10100 There is conflict in CRDs.
This PR enables turning off deployment of the managed velero operator on a cluster by using external labels.  It's a stop gap until MVO is removed from the fleet.

Note this probably orphans the S3 bucket with backups.  The backup objects will expire in 90 days per lifecycle rules.