### PR TITLE
Use non-deprecated serviceAccountName field

### DIFF
--- a/controllers/velero/velero.go
+++ b/controllers/velero/velero.go
@@ -413,7 +413,7 @@ func veleroDeployment(namespace string, platform configv1.PlatformType, veleroIm
 	deployment.Spec.Template.Spec.Containers[0].Ports[0].Protocol = "TCP"
 	deployment.Spec.Template.Spec.Containers[0].TerminationMessagePath = "/dev/termination-log"
 	deployment.Spec.Template.Spec.Containers[0].TerminationMessagePolicy = "File"
-	deployment.Spec.Template.Spec.DeprecatedServiceAccount = "velero"
+	deployment.Spec.Template.Spec.ServiceAccountName = "velero"
 	deployment.Spec.Template.Spec.DNSPolicy = "ClusterFirst"
 	deployment.Spec.Template.Spec.SchedulerName = "default-scheduler"
 	deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{}


### PR DESCRIPTION
This field is thrashing because the old "serviceAccount" field is deprecated and we should be using "serviceAccountName". This new field has been around for some time.