### PR TITLE
Set deprecated serviceAccount field too

### DIFF
--- a/controllers/velero/velero.go
+++ b/controllers/velero/velero.go
@@ -413,6 +413,7 @@ func veleroDeployment(namespace string, platform configv1.PlatformType, veleroIm
 	deployment.Spec.Template.Spec.Containers[0].Ports[0].Protocol = "TCP"
 	deployment.Spec.Template.Spec.Containers[0].TerminationMessagePath = "/dev/termination-log"
 	deployment.Spec.Template.Spec.Containers[0].TerminationMessagePolicy = "File"
+	deployment.Spec.Template.Spec.DeprecatedServiceAccount = "velero"
 	deployment.Spec.Template.Spec.ServiceAccountName = "velero"
 	deployment.Spec.Template.Spec.DNSPolicy = "ClusterFirst"
 	deployment.Spec.Template.Spec.SchedulerName = "default-scheduler"


### PR DESCRIPTION
Follow up to #179, as apparently you need to set both if you want a deepequal to work as they are aliases of each other.