### PR TITLE
Remove velero-operator deployment from STS clusters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -35,6 +35,10 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
+      matchExpressions:
+        - key: api.openshift.com/sts
+          operator: NotIn
+          values: ["true"]
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
PR updates the MVO SSS to not deploy velero-operator on STS clusters.

https://issues.redhat.com/browse/OSD-20950 