### PR TITLE
OSD-20975: Not deploying MVO on GCP WIF clusters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -39,6 +39,9 @@ objects:
         - key: api.openshift.com/sts
           operator: NotIn
           values: ["true"]
+        - key: api.openshift.com/wif
+          operator: NotIn
+          values: ["true"]
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
Lets make sure MVO (Managed Velero Operator) is not deployed on OSD clusters running on GCP with WIF (Workload Identity Federation) enabled.
WIF is the GCP equivalent of AWS STS; both are implementing OAuth 2.0. Our policy in that managed clusters should only deploy base operators (i.e. operators that come with OCP) when OAuth 2.0 is in use; indeed we want to keep to a minimal the actions eventually performed by the cluster on the customer cloud provider account when this authentication scheme is in use.
This excludes MVO which is:
- Not a "base" operator, that is to say not an operator bundled with OCP
- Accessing the customer cloud provider

PR is linked to this one: https://github.com/openshift/managed-cluster-config/pull/2188