### PR TITLE
Add FLs and TLs as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,5 +6,7 @@ approvers:
 - cblecker
 - luis-falcon
 - dustman9000
+- srep-functional-leads
+- srep-team-leads
 maintainers:
 - cblecker


### PR DESCRIPTION
Make FLs and TLs approvers for cases where standard approvers aren't suitable/are hard to reach.

Ref [OSD-25197](https://issues.redhat.com//browse/OSD-25197)