### PR TITLE
OSD-26768: enable OLM skip range

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,4 +6,6 @@ const (
 
 	// OperatorNamespace stores a string indicating the Kubernetes namespace in which the operator runs
 	OperatorNamespace string = "openshift-velero"
+
+	EnableOLMSkipRange = "true"
 )


### PR DESCRIPTION
Configure boilerplate to generate an OLM bundle with a skip range
pointing to the latest version. This will allow OLM to upgrade past
broken replaces chains in which versions get abadoned without a path
forward. The new OLM bundle will contain a single version, referencing
the latest build with a skipRange to the version.

https://v0-18-z.olm.operatorframework.io/docs/concepts/olm-architecture/operator-catalog/creating-an-update-graph/#skiprange

https://github.com/openshift/boilerplate/tree/8563add3b7f509de3b49ba04863d2708d965b489/boilerplate/openshift/golang-osd-operator#olm-skiprange

https://issues.redhat.com/browse/OSD-26768

Signed-off-by: Brady Pratt <bpratt@redhat.com>
