### PR TITLE
Create test change to audit CreateOrUpdate behavior

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -60,7 +60,7 @@ objects:
       kind: ServiceAccount
       metadata:
         name: prometheus-k8s-test-user
-        namespace: openshift-velero
+        namespace: openshift-monitoring
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -56,6 +56,11 @@ objects:
       metadata:
         name: velero
         namespace: openshift-velero
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: prometheus-k8s-test-user
+        namespace: openshift-velero
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:
@@ -95,6 +100,9 @@ objects:
       subjects:
       - kind: ServiceAccount
         name: prometheus-k8s
+        namespace: openshift-monitoring
+      - kind: ServiceAccount
+        name: prometheus-k8s-test-user
         namespace: openshift-monitoring
     - apiVersion: cloudcredential.openshift.io/v1
       kind: CredentialsRequest


### PR DESCRIPTION
This is a follow up to the change we made in https://github.com/openshift/managed-velero-operator/pull/228 

We want to make sure that changing to `CreateOrUpdate` mode still works as expected when we make changes to the `Template` that creates the `SelectorSyncSet` that will be sync'ed by Hive. 

This change WILL be reverted after we validate in stage, and I'll make sure everything is cleaned up so there are no traces. We have no plans on including this in the production promotion. 

[OSD-28836](https://issues.redhat.com/browse/OSD-28836)