### PR TITLE
Revert - Create test change to audit CreateOrUpdate behavior

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -56,11 +56,6 @@ objects:
       metadata:
         name: velero
         namespace: openshift-velero
-    - apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        name: prometheus-k8s-test-user
-        namespace: openshift-monitoring
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:
@@ -100,9 +95,6 @@ objects:
       subjects:
       - kind: ServiceAccount
         name: prometheus-k8s
-        namespace: openshift-monitoring
-      - kind: ServiceAccount
-        name: prometheus-k8s-test-user
         namespace: openshift-monitoring
     - apiVersion: cloudcredential.openshift.io/v1
       kind: CredentialsRequest


### PR DESCRIPTION
As planned, this PR is to revert the changes we made in https://github.com/openshift/managed-velero-operator/pull/229 so we can observe how `CreateOrUpdate` mode handles removing resources. 

[OSD-28836](https://issues.redhat.com/browse/OSD-28836) 