### PR TITLE
Remove Subscription, OperatorGroup and CatalogSources from OLM

### DIFF
--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -86,11 +86,13 @@ spec:
               set -euxo pipefail
               # CUSTOMIZE: Update the label selector for your operator
               # Example pattern: operators.coreos.com/OPERATOR_NAME.NAMESPACE
-              oc -n openshift-velero delete csv -l "operators.coreos.com/managed-velero-operator.openshift-velero" || true
               
               # Delete subscriptions
               oc -n openshift-velero delete subscriptions.operators.coreos.com managed-velero-operator --ignore-not-found=true
               
+              # Delete CSV after deleting subscriptions
+              oc -n openshift-velero delete csv -l "operators.coreos.com/managed-velero-operator.openshift-velero" || true
+
               # Delete operatorgroups
               oc -n openshift-velero delete operatorgroups managed-velero-operator-og --ignore-not-found=true
 

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -32,6 +32,8 @@ rules:
     resources:
       - clusterserviceversions
       - subscriptions
+      - catalogsources
+      - operatorgroups
     verbs:
       - list
       - get
@@ -86,11 +88,14 @@ spec:
               # Example pattern: operators.coreos.com/OPERATOR_NAME.NAMESPACE
               oc -n openshift-velero delete csv -l "operators.coreos.com/managed-velero-operator.openshift-velero" || true
               
-              # CUSTOMIZE: Add any additional cleanup logic here
-              # Examples:
-              # - Delete subscriptions
-              # - Delete operator groups
-              # - Clean up custom resources
+              # Delete subscriptions
+              oc -n openshift-velero delete subscriptions.operators.coreos.com managed-velero-operator --ignore-not-found=true
+              
+              # Delete operatorgroups
+              oc -n openshift-velero delete operatorgroups managed-velero-operator-og --ignore-not-found=true
+
+              # Delete catalogsources
+              oc -n openshift-velero delete catalogsources managed-velero-operator-catalog --ignore-not-found=true
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Finalize the OLM-cleanup job to remove Subscription, OperatorGroup and CatalogSources from OLM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the cleanup process to comprehensively remove all associated Operator Lifecycle Manager resources, including subscriptions, operator groups, and catalog sources, during Velero operator removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->