### PR TITLE
ROSA-745: boilerplate-update and enable MintMaker gomod

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>openshift/boilerplate//.github/renovate.json"
+  ],
+  "enabledManagers": [
+    "tekton",
+    "gomod"
   ]
 }


### PR DESCRIPTION
## Summary

- `make boilerplate-update` (includes boilerplate #748 dependabot template)
- `.github/renovate.json` — `enabledManagers: [tekton, gomod]` for MintMaker gomod PRs

## Test plan

- [ ] CI green

Jira: [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded Renovate settings to cover additional dependency managers, helping keep more project dependencies up to date automatically.
  * Cleaned up the configuration structure for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->